### PR TITLE
Clean header processing

### DIFF
--- a/lib/dnsimple.ex
+++ b/lib/dnsimple.ex
@@ -127,67 +127,39 @@ defmodule Dnsimple do
     Issues a GET request to the given url processing the listing options first.
     """
     @spec get_list(Client.t, binary, Keyword.t) :: HTTPoison.Response.t | HTTPoison.AsyncResponse.t
-    def get_list(client, url, options \\ []), do: get2(client, url, ListOptions.prepare(options))
+    def get_list(client, url, options \\ []), do: get(client, url, ListOptions.prepare(options))
 
     @doc """
     Issues a GET request to the given url.
     """
-    @spec get(Client.t, binary, headers, Keyword.t) :: HTTPoison.Response.t | HTTPoison.AsyncResponse.t
-    def get(client, url, headers \\ [], options \\ []), do: execute(client, :get, url, "", headers, options)
-
-    @spec get2(Client.t, binary, Keyword.t) :: HTTPoison.Response.t | HTTPoison.AsyncResponse.t
-    def get2(client, url, options \\ []), do: execute2(client, :get, url, "", options)
+    @spec get(Client.t, binary, Keyword.t) :: HTTPoison.Response.t | HTTPoison.AsyncResponse.t
+    def get(client, url, options \\ []), do: execute(client, :get, url, "", options)
 
     @doc """
     Issues a POST request to the given url.
     """
-    @spec post(Client.t, binary, body, headers, Keyword.t) :: HTTPoison.Response.t | HTTPoison.AsyncResponse.t
-    def post(client, url, body, headers \\ [], options \\ []), do: execute(client, :post, url, body, headers, options)
-
-    @spec post2(Client.t, binary, body, Keyword.t) :: HTTPoison.Response.t | HTTPoison.AsyncResponse.t
-    def post2(client, url, body, options \\ []), do: execute2(client, :post, url, body, options)
+    @spec post(Client.t, binary, body, Keyword.t) :: HTTPoison.Response.t | HTTPoison.AsyncResponse.t
+    def post(client, url, body, options \\ []), do: execute(client, :post, url, body, options)
 
     @doc """
     Issues a PUT request to the given url.
     """
-    @spec put(Client.t, binary, body, headers, Keyword.t) :: HTTPoison.Response.t | HTTPoison.AsyncResponse.t
-    def put(client, url, body, headers \\ [], options \\ []), do: execute(client, :put, url, body, headers, options)
-
-    @spec put2(Client.t, binary, body, Keyword.t) :: HTTPoison.Response.t | HTTPoison.AsyncResponse.t
-    def put2(client, url, body, options \\ []), do: execute2(client, :put, url, body, options)
+    @spec put(Client.t, binary, body, Keyword.t) :: HTTPoison.Response.t | HTTPoison.AsyncResponse.t
+    def put(client, url, body, options \\ []), do: execute(client, :put, url, body, options)
 
     @doc """
     Issues a PATCH request to the given url.
     """
-    @spec patch(Client.t, binary, body, headers, Keyword.t) :: HTTPoison.Response.t | HTTPoison.AsyncResponse.t
-    def patch(client, url, body, headers \\ [], options \\ []), do: execute(client, :patch, url, body, headers, options)
-
-    @spec patch2(Client.t, binary, body, Keyword.t) :: HTTPoison.Response.t | HTTPoison.AsyncResponse.t
-    def patch2(client, url, body, options \\ []), do: execute2(client, :patch, url, body, options)
+    @spec patch(Client.t, binary, body, Keyword.t) :: HTTPoison.Response.t | HTTPoison.AsyncResponse.t
+    def patch(client, url, body, options \\ []), do: execute(client, :patch, url, body, options)
 
     @doc """
     Issues a DELETE request to the given url.
     """
-    @spec delete(Client.t, binary, headers, Keyword.t) :: HTTPoison.Response.t | HTTPoison.AsyncResponse.t
-    def delete(client, url, headers \\ [], options \\ []), do: execute(client, :delete, url, "", headers, options)
+    @spec delete(Client.t, binary, Keyword.t) :: HTTPoison.Response.t | HTTPoison.AsyncResponse.t
+    def delete(client, url, options \\ []), do: execute(client, :delete, url, "", options)
 
-    @spec delete2(Client.t, binary, Keyword.t) :: HTTPoison.Response.t | HTTPoison.AsyncResponse.t
-    def delete2(client, url, options \\ []), do: execute2(client, :delete, url, "", options)
-
-    def execute(client, method, url, body \\ "", headers \\ [], options \\ []) do
-      headers = headers ++ [
-        {"Accept", "application/json"},
-        {"User-Agent", format_user_agent(client.user_agent)},
-        {"Authorization", "Bearer #{client.access_token}"},
-      ]
-
-      { body, headers } = process_request_body(body, headers)
-
-      request(client, method, url, body, headers, options)
-      |> check_response
-    end
-
-    def execute2(client, method, url, body \\ "", options \\ []) do
+    def execute(client, method, url, body \\ "", options \\ []) do
       {headers, other_options} = Keyword.split(options, [:headers])
 
       headers = headers ++ [

--- a/lib/dnsimple.ex
+++ b/lib/dnsimple.ex
@@ -121,6 +121,12 @@ defmodule Dnsimple do
     end
 
     @doc """
+    Issues a GET request to the given url processing the listing options first.
+    """
+    @spec get_list(Client.t, binary, Keyword.t) :: HTTPoison.Response.t | HTTPoison.AsyncResponse.t
+    def get_list(client, url, options \\ []), do: get2(client, url, ListOptions.prepare(options))
+
+    @doc """
     Issues a GET request to the given url.
     """
     @spec get(Client.t, binary, headers, Keyword.t) :: HTTPoison.Response.t | HTTPoison.AsyncResponse.t

--- a/lib/dnsimple.ex
+++ b/lib/dnsimple.ex
@@ -10,7 +10,10 @@ defmodule Dnsimple do
     def prepare(options) do
       {params, options} = Enum.reduce(@known_params, {[], options}, &extract_param/2)
 
-      Keyword.merge([params: params], options)
+      case Enum.empty?(params) do
+        true  -> options
+        false -> Keyword.merge([params: params], options)
+      end
     end
 
     defp extract_param(:filter = option, {params, options}) do

--- a/lib/dnsimple.ex
+++ b/lib/dnsimple.ex
@@ -126,11 +126,17 @@ defmodule Dnsimple do
     @spec get(Client.t, binary, headers, Keyword.t) :: HTTPoison.Response.t | HTTPoison.AsyncResponse.t
     def get(client, url, headers \\ [], options \\ []), do: execute(client, :get, url, "", headers, options)
 
+    @spec get2(Client.t, binary, Keyword.t) :: HTTPoison.Response.t | HTTPoison.AsyncResponse.t
+    def get2(client, url, options \\ []), do: execute2(client, :get, url, "", options)
+
     @doc """
     Issues a POST request to the given url.
     """
     @spec post(Client.t, binary, body, headers, Keyword.t) :: HTTPoison.Response.t | HTTPoison.AsyncResponse.t
     def post(client, url, body, headers \\ [], options \\ []), do: execute(client, :post, url, body, headers, options)
+
+    @spec post2(Client.t, binary, body, Keyword.t) :: HTTPoison.Response.t | HTTPoison.AsyncResponse.t
+    def post2(client, url, body, options \\ []), do: execute2(client, :post, url, body, options)
 
     @doc """
     Issues a PUT request to the given url.
@@ -138,11 +144,17 @@ defmodule Dnsimple do
     @spec put(Client.t, binary, body, headers, Keyword.t) :: HTTPoison.Response.t | HTTPoison.AsyncResponse.t
     def put(client, url, body, headers \\ [], options \\ []), do: execute(client, :put, url, body, headers, options)
 
+    @spec put2(Client.t, binary, body, Keyword.t) :: HTTPoison.Response.t | HTTPoison.AsyncResponse.t
+    def put2(client, url, body, options \\ []), do: execute2(client, :put, url, body, options)
+
     @doc """
     Issues a PATCH request to the given url.
     """
     @spec patch(Client.t, binary, body, headers, Keyword.t) :: HTTPoison.Response.t | HTTPoison.AsyncResponse.t
     def patch(client, url, body, headers \\ [], options \\ []), do: execute(client, :patch, url, body, headers, options)
+
+    @spec patch2(Client.t, binary, body, Keyword.t) :: HTTPoison.Response.t | HTTPoison.AsyncResponse.t
+    def patch2(client, url, body, options \\ []), do: execute2(client, :patch, url, body, options)
 
     @doc """
     Issues a DELETE request to the given url.
@@ -150,6 +162,8 @@ defmodule Dnsimple do
     @spec delete(Client.t, binary, headers, Keyword.t) :: HTTPoison.Response.t | HTTPoison.AsyncResponse.t
     def delete(client, url, headers \\ [], options \\ []), do: execute(client, :delete, url, "", headers, options)
 
+    @spec delete2(Client.t, binary, Keyword.t) :: HTTPoison.Response.t | HTTPoison.AsyncResponse.t
+    def delete2(client, url, options \\ []), do: execute2(client, :delete, url, "", options)
 
     def execute(client, method, url, body \\ "", headers \\ [], options \\ []) do
       headers = headers ++ [
@@ -163,6 +177,22 @@ defmodule Dnsimple do
       request(client, method, url, body, headers, options)
       |> check_response
     end
+
+    def execute2(client, method, url, body \\ "", options \\ []) do
+      {headers, other_options} = Keyword.split(options, [:headers])
+
+      headers = headers ++ [
+        {"Accept", "application/json"},
+        {"User-Agent", format_user_agent(client.user_agent)},
+        {"Authorization", "Bearer #{client.access_token}"},
+      ]
+
+      {body, headers} = process_request_body(body, headers)
+
+      request(client, method, url, body, headers, other_options)
+      |> check_response
+    end
+
 
     @doc """
     Sends an HTTP request and returns an HTTP response.

--- a/lib/dnsimple/accounts.ex
+++ b/lib/dnsimple/accounts.ex
@@ -1,6 +1,6 @@
 defmodule Dnsimple.Accounts do
   @moduledoc """
-  AccountsService handles communication with the account related
+  Accounts handles communication with the account related
   methods of the DNSimple API.
 
   See https://developer.dnsimple.com/v2/accounts/

--- a/lib/dnsimple/accounts.ex
+++ b/lib/dnsimple/accounts.ex
@@ -9,7 +9,6 @@ defmodule Dnsimple.Accounts do
   alias Dnsimple.Client
   alias Dnsimple.Account
   alias Dnsimple.Response
-  alias Dnsimple.ListOptions
 
 
   @doc """
@@ -19,8 +18,9 @@ defmodule Dnsimple.Accounts do
   """
   @spec accounts(Client.t) :: Response.t
   def accounts(client, options \\ []) do
-    {headers, opts} = Client.headers(options)
-    Client.get(client, Client.versioned("/accounts"), headers, ListOptions.prepare(opts))
+    url = Client.versioned("/accounts")
+
+    Client.get(client, url, options)
     |> Response.parse(Account)
   end
 

--- a/lib/dnsimple/certificates.ex
+++ b/lib/dnsimple/certificates.ex
@@ -6,6 +6,7 @@ defmodule Dnsimple.Certificates do
   @see https://developer.dnsimple.com/v2/domains/certificates/
   """
 
+  alias Dnsimple.List
   alias Dnsimple.Client
   alias Dnsimple.Response
   alias Dnsimple.Certificate
@@ -20,7 +21,7 @@ defmodule Dnsimple.Certificates do
   def certificates(client, account_id, domain_id, options \\ []) do
     url = Client.versioned("/#{account_id}/domains/#{domain_id}/certificates")
 
-    Client.get_list(client, url, options)
+    List.get(client, url, options)
     |> Response.parse(Certificate)
   end
 

--- a/lib/dnsimple/certificates.ex
+++ b/lib/dnsimple/certificates.ex
@@ -10,6 +10,7 @@ defmodule Dnsimple.Certificates do
   alias Dnsimple.Response
   alias Dnsimple.Certificate
 
+
   @doc """
   List certificates.
 

--- a/lib/dnsimple/certificates.ex
+++ b/lib/dnsimple/certificates.ex
@@ -1,13 +1,12 @@
 defmodule Dnsimple.Certificates do
   @moduledoc """
-  This module handles communication with the DNSimple API responsible of 
+  This module handles communication with the DNSimple API responsible of
   handling SSL certificates.
 
   @see https://developer.dnsimple.com/v2/domains/certificates/
   """
 
   alias Dnsimple.Client
-  alias Dnsimple.ListOptions
   alias Dnsimple.Response
   alias Dnsimple.Certificate
 
@@ -18,8 +17,9 @@ defmodule Dnsimple.Certificates do
   """
   @spec certificates(Client.t, String.t | integer, String.t | integer) :: Response.t
   def certificates(client, account_id, domain_id, options \\ []) do
-    {headers, opts} = Client.headers(options)
-    Client.get(client, Client.versioned("/#{account_id}/domains/#{domain_id}/certificates"), headers, ListOptions.prepare(opts))
+    url = Client.versioned("/#{account_id}/domains/#{domain_id}/certificates")
+
+    Client.get_list(client, url, options)
     |> Response.parse(Certificate)
   end
 
@@ -30,8 +30,9 @@ defmodule Dnsimple.Certificates do
   """
   @spec certificate(Client.t, String.t | integer, String.t | integer, String.t | integer, Keyword.t) :: Response.t
   def certificate(client, account_id, domain_id, certificate_id, options \\ []) do
-    {headers, opts} = Client.headers(options)
-    Client.get(client, Client.versioned("/#{account_id}/domains/#{domain_id}/certificates/#{certificate_id}"), headers, opts)
+    url = Client.versioned("/#{account_id}/domains/#{domain_id}/certificates/#{certificate_id}")
+
+    Client.get2(client, url, options)
     |> Response.parse(Certificate)
   end
 
@@ -42,8 +43,9 @@ defmodule Dnsimple.Certificates do
   """
   @spec download(Client.t, String.t | integer, String.t | integer, String.t | integer, Keyword.t) :: Response.t
   def download(client, account_id, domain_id, certificate_id, options \\ []) do
-    {headers, opts} = Client.headers(options)
-    Client.get(client, Client.versioned("/#{account_id}/domains/#{domain_id}/certificates/#{certificate_id}/download"), headers, opts)
+    url = Client.versioned("/#{account_id}/domains/#{domain_id}/certificates/#{certificate_id}/download")
+
+    Client.get2(client, url, options)
     |> Response.parse(Certificate)
   end
 
@@ -54,8 +56,9 @@ defmodule Dnsimple.Certificates do
   """
   @spec private_key(Client.t, String.t | integer, String.t | integer, String.t | integer, Keyword.t) :: Response.t
   def private_key(client, account_id, domain_id, certificate_id, options \\ []) do
-    {headers, opts} = Client.headers(options)
-    Client.get(client, Client.versioned("/#{account_id}/domains/#{domain_id}/certificates/#{certificate_id}/private_key"), headers, opts)
+    url = Client.versioned("/#{account_id}/domains/#{domain_id}/certificates/#{certificate_id}/private_key")
+
+    Client.get2(client, url, options)
     |> Response.parse(Certificate)
   end
 end

--- a/lib/dnsimple/certificates.ex
+++ b/lib/dnsimple/certificates.ex
@@ -32,7 +32,7 @@ defmodule Dnsimple.Certificates do
   def certificate(client, account_id, domain_id, certificate_id, options \\ []) do
     url = Client.versioned("/#{account_id}/domains/#{domain_id}/certificates/#{certificate_id}")
 
-    Client.get2(client, url, options)
+    Client.get(client, url, options)
     |> Response.parse(Certificate)
   end
 
@@ -45,7 +45,7 @@ defmodule Dnsimple.Certificates do
   def download(client, account_id, domain_id, certificate_id, options \\ []) do
     url = Client.versioned("/#{account_id}/domains/#{domain_id}/certificates/#{certificate_id}/download")
 
-    Client.get2(client, url, options)
+    Client.get(client, url, options)
     |> Response.parse(Certificate)
   end
 
@@ -58,7 +58,8 @@ defmodule Dnsimple.Certificates do
   def private_key(client, account_id, domain_id, certificate_id, options \\ []) do
     url = Client.versioned("/#{account_id}/domains/#{domain_id}/certificates/#{certificate_id}/private_key")
 
-    Client.get2(client, url, options)
+    Client.get(client, url, options)
     |> Response.parse(Certificate)
   end
+
 end

--- a/lib/dnsimple/contacts.ex
+++ b/lib/dnsimple/contacts.ex
@@ -1,7 +1,6 @@
 defmodule Dnsimple.Contacts do
   alias Dnsimple.Client
   alias Dnsimple.Response
-  alias Dnsimple.ListOptions
   alias Dnsimple.Contact
 
   @moduledoc """
@@ -19,9 +18,8 @@ defmodule Dnsimple.Contacts do
   @spec contacts(Client.t, String.t | integer) :: Response.t
   def contacts(client, account_id, options \\ []) do
     url = Client.versioned("/#{account_id}/contacts")
-    {headers, opts} = Client.headers(options)
 
-    Client.get(client, url, headers, ListOptions.prepare(opts))
+    Client.get_list(client, url, options)
     |> Response.parse(Contact)
   end
 
@@ -33,9 +31,8 @@ defmodule Dnsimple.Contacts do
   @spec contact(Client.t, String.t | integer, String.t | integer, Keyword.t) :: Response.t
   def contact(client, account_id, contact_id, options \\ []) do
     url = Client.versioned("/#{account_id}/contacts/#{contact_id}")
-    {headers, opts} = Client.headers(options)
 
-    Client.get(client, url, headers, opts)
+    Client.get2(client, url, options)
     |> Response.parse(Contact)
   end
 
@@ -47,9 +44,8 @@ defmodule Dnsimple.Contacts do
   @spec create_contact(Client.t, String.t | integer, Keyword.t, Keyword.t) :: Response.t
   def create_contact(client, account_id, attributes, options \\ []) do
     url = Client.versioned("/#{account_id}/contacts")
-    {headers, opts} = Client.headers(options)
 
-    Client.post(client, url, attributes, headers, opts)
+    Client.post2(client, url, attributes, options)
     |> Response.parse(Contact)
   end
 
@@ -62,9 +58,8 @@ defmodule Dnsimple.Contacts do
   @spec update_contact(Client.t, String.t | integer, String.t | integer, Keyword.t, Keyword.t) :: Response.t
   def update_contact(client, account_id, contact_id, attributes, options \\ []) do
     url = Client.versioned("/#{account_id}/contacts/#{contact_id}")
-    {headers, opts} = Client.headers(options)
 
-    Client.patch(client, url, attributes, headers, opts)
+    Client.patch(client, url, attributes, options)
     |> Response.parse(Contact)
   end
 
@@ -76,9 +71,8 @@ defmodule Dnsimple.Contacts do
   @spec delete_contact(Client.t, String.t | integer, String.t | integer, Keyword.t) :: Response.t
   def delete_contact(client, account_id, contact_id, options \\ []) do
     url = Client.versioned("/#{account_id}/contacts/#{contact_id}")
-    {headers, opts} = Client.headers(options)
 
-    Client.delete(client, url, headers, opts)
+    Client.delete(client, url, options)
     |> Response.parse(nil)
   end
 

--- a/lib/dnsimple/contacts.ex
+++ b/lib/dnsimple/contacts.ex
@@ -1,13 +1,14 @@
 defmodule Dnsimple.Contacts do
-  alias Dnsimple.Client
-  alias Dnsimple.Response
-  alias Dnsimple.Contact
-
   @moduledoc """
   Represents the operations that can be performed with contacts.
 
   See: https://developer.dnsimple.com/v2/contacts/
   """
+
+  alias Dnsimple.List
+  alias Dnsimple.Client
+  alias Dnsimple.Response
+  alias Dnsimple.Contact
 
 
   @doc """

--- a/lib/dnsimple/contacts.ex
+++ b/lib/dnsimple/contacts.ex
@@ -32,7 +32,7 @@ defmodule Dnsimple.Contacts do
   def contact(client, account_id, contact_id, options \\ []) do
     url = Client.versioned("/#{account_id}/contacts/#{contact_id}")
 
-    Client.get2(client, url, options)
+    Client.get(client, url, options)
     |> Response.parse(Contact)
   end
 
@@ -45,7 +45,7 @@ defmodule Dnsimple.Contacts do
   def create_contact(client, account_id, attributes, options \\ []) do
     url = Client.versioned("/#{account_id}/contacts")
 
-    Client.post2(client, url, attributes, options)
+    Client.post(client, url, attributes, options)
     |> Response.parse(Contact)
   end
 

--- a/lib/dnsimple/contacts.ex
+++ b/lib/dnsimple/contacts.ex
@@ -20,7 +20,7 @@ defmodule Dnsimple.Contacts do
   def contacts(client, account_id, options \\ []) do
     url = Client.versioned("/#{account_id}/contacts")
 
-    Client.get_list(client, url, options)
+    List.get(client, url, options)
     |> Response.parse(Contact)
   end
 

--- a/lib/dnsimple/domains.ex
+++ b/lib/dnsimple/domains.ex
@@ -7,7 +7,6 @@ defmodule Dnsimple.Domains do
   """
 
   alias Dnsimple.Client
-  alias Dnsimple.ListOptions
   alias Dnsimple.Response
   alias Dnsimple.Domain
 
@@ -19,8 +18,9 @@ defmodule Dnsimple.Domains do
   """
   @spec domains(Client.t, String.t | integer) :: Response.t
   def domains(client, account_id, options \\ []) do
-    {headers, opts} = Client.headers(options)
-    Client.get(client, Client.versioned("/#{account_id}/domains"), headers, ListOptions.prepare(opts))
+    url = Client.versioned("/#{account_id}/domains")
+
+    Client.get_list(client, url, options)
     |> Response.parse(Domain)
   end
 
@@ -53,8 +53,9 @@ defmodule Dnsimple.Domains do
   """
   @spec create_domain(Client.t, String.t | integer, map, Keyword.t) :: Response.t
   def create_domain(client, account_id, attributes, options \\ []) do
-    {headers, opts} = Client.headers(options)
-    Client.post(client, Client.versioned("/#{account_id}/domains"), attributes, headers, opts)
+    url = Client.versioned("/#{account_id}/domains")
+
+    Client.post2(client, url, attributes, options)
     |> Response.parse(Domain)
   end
 
@@ -65,8 +66,9 @@ defmodule Dnsimple.Domains do
   """
   @spec domain(Client.t, String.t | integer, String.t | integer, Keyword.t) :: Response.t
   def domain(client, account_id, domain_id, options \\ []) do
-    {headers, opts} = Client.headers(options)
-    Client.get(client, Client.versioned("/#{account_id}/domains/#{domain_id}"), headers, opts)
+    url = Client.versioned("/#{account_id}/domains/#{domain_id}")
+
+    Client.get2(client, url, options)
     |> Response.parse(Domain)
   end
 
@@ -77,8 +79,9 @@ defmodule Dnsimple.Domains do
   """
   @spec delete_domain(Client.t, String.t | integer, String.t | integer, Keyword.t) :: Response.t
   def delete_domain(client, account_id, domain_id, options \\ []) do
-    {headers, opts} = Client.headers(options)
-    Client.delete(client, Client.versioned("/#{account_id}/domains/#{domain_id}"), headers, opts)
+    url = Client.versioned("/#{account_id}/domains/#{domain_id}")
+
+    Client.delete2(client, url, options)
     |> Response.parse(nil)
   end
 
@@ -90,9 +93,8 @@ defmodule Dnsimple.Domains do
   @spec reset_domain_token(Client.t, String.t | integer, String.t | integer, Keyword.t) :: Response.t
   def reset_domain_token(client, account_id, domain_id, options \\ []) do
     url = Client.versioned("/#{account_id}/domains/#{domain_id}/token")
-    {headers, opts} = Client.headers(options)
 
-    Client.post(client, url, _body = [], headers, opts)
+    Client.post2(client, url, _body = [], options)
     |> Response.parse(Domain)
   end
 

--- a/lib/dnsimple/domains.ex
+++ b/lib/dnsimple/domains.ex
@@ -6,6 +6,7 @@ defmodule Dnsimple.Domains do
   See https://developer.dnsimple.com/v2/domains/
   """
 
+  alias Dnsimple.List
   alias Dnsimple.Client
   alias Dnsimple.Response
   alias Dnsimple.Domain
@@ -20,7 +21,7 @@ defmodule Dnsimple.Domains do
   def domains(client, account_id, options \\ []) do
     url = Client.versioned("/#{account_id}/domains")
 
-    Client.get_list(client, url, options)
+    List.get(client, url, options)
     |> Response.parse(Domain)
   end
 

--- a/lib/dnsimple/domains.ex
+++ b/lib/dnsimple/domains.ex
@@ -55,7 +55,7 @@ defmodule Dnsimple.Domains do
   def create_domain(client, account_id, attributes, options \\ []) do
     url = Client.versioned("/#{account_id}/domains")
 
-    Client.post2(client, url, attributes, options)
+    Client.post(client, url, attributes, options)
     |> Response.parse(Domain)
   end
 
@@ -68,7 +68,7 @@ defmodule Dnsimple.Domains do
   def domain(client, account_id, domain_id, options \\ []) do
     url = Client.versioned("/#{account_id}/domains/#{domain_id}")
 
-    Client.get2(client, url, options)
+    Client.get(client, url, options)
     |> Response.parse(Domain)
   end
 
@@ -81,7 +81,7 @@ defmodule Dnsimple.Domains do
   def delete_domain(client, account_id, domain_id, options \\ []) do
     url = Client.versioned("/#{account_id}/domains/#{domain_id}")
 
-    Client.delete2(client, url, options)
+    Client.delete(client, url, options)
     |> Response.parse(nil)
   end
 
@@ -94,7 +94,7 @@ defmodule Dnsimple.Domains do
   def reset_domain_token(client, account_id, domain_id, options \\ []) do
     url = Client.versioned("/#{account_id}/domains/#{domain_id}/token")
 
-    Client.post2(client, url, _body = [], options)
+    Client.post(client, url, _body = [], options)
     |> Response.parse(Domain)
   end
 

--- a/lib/dnsimple/identity.ex
+++ b/lib/dnsimple/identity.ex
@@ -7,7 +7,7 @@ defmodule Dnsimple.Identity do
   def whoami(client, options \\ []) do
     url = Client.versioned("/whoami")
 
-    Client.get2(client, url, options)
+    Client.get(client, url, options)
     |> Response.parse(Whoami)
   end
 

--- a/lib/dnsimple/identity.ex
+++ b/lib/dnsimple/identity.ex
@@ -5,9 +5,9 @@ defmodule Dnsimple.Identity do
 
   @spec whoami(Client.t, Keyword.t) :: Response.t
   def whoami(client, options \\ []) do
-    {headers, opts} = Client.headers(options)
+    url = Client.versioned("/whoami")
 
-    Client.get(client, Client.versioned("/whoami"), headers, opts)
+    Client.get2(client, url, options)
     |> Response.parse(Whoami)
   end
 

--- a/lib/dnsimple/oauth.ex
+++ b/lib/dnsimple/oauth.ex
@@ -25,10 +25,9 @@ defmodule Dnsimple.Oauth do
   def exchange_authorization_for_token(client, attributes, options \\ []) do
     url        = Client.versioned("/oauth/access_token")
     attributes = Map.merge(attributes, %{grant_type: "authorization_code"})
-    {headers, opts} = Client.headers(options)
 
-    Client.post(client, url, attributes, headers, opts)
-      |> Response.parse(OauthToken)
+    Client.post2(client, url, attributes, options)
+    |> Response.parse(OauthToken)
   end
 
 end

--- a/lib/dnsimple/oauth.ex
+++ b/lib/dnsimple/oauth.ex
@@ -26,7 +26,7 @@ defmodule Dnsimple.Oauth do
     url        = Client.versioned("/oauth/access_token")
     attributes = Map.merge(attributes, %{grant_type: "authorization_code"})
 
-    Client.post2(client, url, attributes, options)
+    Client.post(client, url, attributes, options)
     |> Response.parse(OauthToken)
   end
 

--- a/lib/dnsimple/registrar.ex
+++ b/lib/dnsimple/registrar.ex
@@ -13,10 +13,9 @@ defmodule Dnsimple.Registrar do
   @spec check_domain(Client.t, String.t, String.t, Keyword.t) :: Response.t
   def check_domain(client, account_id, domain_name, options \\ []) do
     url = Client.versioned("/#{account_id}/registrar/domains/#{domain_name}/check")
-    {headers, opts} = Client.headers(options)
 
-    Client.get(client, url, headers, opts)
-      |> Response.parse(DomainCheck)
+    Client.get2(client, url, options)
+    |> Response.parse(DomainCheck)
   end
 
   @doc """
@@ -27,10 +26,9 @@ defmodule Dnsimple.Registrar do
   @spec register_domain(Client.t, String.t, String.t, Keyword.t, Keyword.t) :: Response.t
   def register_domain(client, account_id, domain_name, attributes \\ [], options \\ []) do
     url = Client.versioned("/#{account_id}/registrar/domains/#{domain_name}/registration")
-    {headers, opts} = Client.headers(options)
 
-    Client.post(client, url, attributes, headers, opts)
-      |> Response.parse(Domain)
+    Client.post2(client, url, attributes, options)
+    |> Response.parse(Domain)
   end
 
   @doc """
@@ -41,10 +39,9 @@ defmodule Dnsimple.Registrar do
   @spec renew_domain(Client.t, String.t, String.t, Keyword.t, Keyword.t) :: Response.t
   def renew_domain(client, account_id, domain_name, attributes \\ [], options \\ []) do
     url = Client.versioned("/#{account_id}/registrar/domains/#{domain_name}/renewal")
-    {headers, opts} = Client.headers(options)
 
-    Client.post(client, url, attributes, headers, opts)
-      |> Response.parse(Domain)
+    Client.post2(client, url, attributes, options)
+    |> Response.parse(Domain)
   end
 
   @doc """
@@ -55,10 +52,9 @@ defmodule Dnsimple.Registrar do
   @spec transfer_domain(Client.t, String.t, String.t, Keyword.t, Keyword.t) :: Response.t
   def transfer_domain(client, account_id, domain_name, attributes \\ [], options \\ []) do
     url = Client.versioned("/#{account_id}/registrar/domains/#{domain_name}/transfer")
-    {headers, opts} = Client.headers(options)
 
-    Client.post(client, url, attributes, headers, opts)
-      |> Response.parse(Domain)
+    Client.post2(client, url, attributes, options)
+    |> Response.parse(Domain)
   end
 
   @doc """
@@ -69,10 +65,9 @@ defmodule Dnsimple.Registrar do
   @spec transfer_domain_out(Client.t, String.t, String.t, Keyword.t) :: Response.t
   def transfer_domain_out(client, account_id, domain_name, options \\ []) do
     url = Client.versioned("/#{account_id}/registrar/domains/#{domain_name}/transfer_out")
-    {headers, opts} = Client.headers(options)
 
-    Client.post(client, url, _body = [], headers, opts)
-      |> Response.parse(nil)
+    Client.post2(client, url, _body = [], options)
+    |> Response.parse(nil)
   end
 
 
@@ -84,10 +79,9 @@ defmodule Dnsimple.Registrar do
   @spec enable_auto_renewal(Client.t, String.t, String.t, Keyword.t) :: Response.t
   def enable_auto_renewal(client, account_id, domain_name, options \\ []) do
     url = Client.versioned("/#{account_id}/registrar/domains/#{domain_name}/auto_renewal")
-    {headers, opts} = Client.headers(options)
 
-    Client.put(client, url, headers, opts)
-      |> Response.parse(nil)
+    Client.put2(client, url, options)
+    |> Response.parse(nil)
   end
 
   @doc """
@@ -98,10 +92,9 @@ defmodule Dnsimple.Registrar do
   @spec disable_auto_renewal(Client.t, String.t, String.t, Keyword.t) :: Response.t
   def disable_auto_renewal(client, account_id, domain_name, options \\ []) do
     url = Client.versioned("/#{account_id}/registrar/domains/#{domain_name}/auto_renewal")
-    {headers, opts} = Client.headers(options)
 
-    Client.delete(client, url, headers, opts)
-      |> Response.parse(nil)
+    Client.delete2(client, url, options)
+    |> Response.parse(nil)
   end
 
 
@@ -113,10 +106,9 @@ defmodule Dnsimple.Registrar do
   @spec whois_privacy(Client.t, String.t, String.t, Keyword.t) :: Response.t
   def whois_privacy(client, account_id, domain_name, options \\ []) do
     url = Client.versioned("/#{account_id}/registrar/domains/#{domain_name}/whois_privacy")
-    {headers, opts} = Client.headers(options)
 
-    Client.get(client, url, headers, opts)
-      |> Response.parse(WhoisPrivacy)
+    Client.get2(client, url, options)
+    |> Response.parse(WhoisPrivacy)
   end
 
   @doc """
@@ -127,10 +119,9 @@ defmodule Dnsimple.Registrar do
   @spec enable_whois_privacy(Client.t, String.t, String.t, Keyword.t) :: Response.t
   def enable_whois_privacy(client, account_id, domain_name, options \\ []) do
     url = Client.versioned("/#{account_id}/registrar/domains/#{domain_name}/whois_privacy")
-    {headers, opts} = Client.headers(options)
 
-    Client.put(client, url, _body = [], headers, opts)
-      |> Response.parse(WhoisPrivacy)
+    Client.put2(client, url, _body = [], options)
+    |> Response.parse(WhoisPrivacy)
   end
 
   @doc """
@@ -141,11 +132,9 @@ defmodule Dnsimple.Registrar do
   @spec disable_whois_privacy(Client.t, String.t, String.t, Keyword.t) :: Response.t
   def disable_whois_privacy(client, account_id, domain_name, options \\ []) do
     url = Client.versioned("/#{account_id}/registrar/domains/#{domain_name}/whois_privacy")
-    {headers, opts} = Client.headers(options)
 
-    Client.delete(client, url, headers, opts)
-      |> Response.parse(WhoisPrivacy)
+    Client.delete2(client, url, options)
+    |> Response.parse(WhoisPrivacy)
   end
-
 
 end

--- a/lib/dnsimple/registrar.ex
+++ b/lib/dnsimple/registrar.ex
@@ -14,7 +14,7 @@ defmodule Dnsimple.Registrar do
   def check_domain(client, account_id, domain_name, options \\ []) do
     url = Client.versioned("/#{account_id}/registrar/domains/#{domain_name}/check")
 
-    Client.get2(client, url, options)
+    Client.get(client, url, options)
     |> Response.parse(DomainCheck)
   end
 
@@ -27,7 +27,7 @@ defmodule Dnsimple.Registrar do
   def register_domain(client, account_id, domain_name, attributes \\ [], options \\ []) do
     url = Client.versioned("/#{account_id}/registrar/domains/#{domain_name}/registration")
 
-    Client.post2(client, url, attributes, options)
+    Client.post(client, url, attributes, options)
     |> Response.parse(Domain)
   end
 
@@ -40,7 +40,7 @@ defmodule Dnsimple.Registrar do
   def renew_domain(client, account_id, domain_name, attributes \\ [], options \\ []) do
     url = Client.versioned("/#{account_id}/registrar/domains/#{domain_name}/renewal")
 
-    Client.post2(client, url, attributes, options)
+    Client.post(client, url, attributes, options)
     |> Response.parse(Domain)
   end
 
@@ -53,7 +53,7 @@ defmodule Dnsimple.Registrar do
   def transfer_domain(client, account_id, domain_name, attributes \\ [], options \\ []) do
     url = Client.versioned("/#{account_id}/registrar/domains/#{domain_name}/transfer")
 
-    Client.post2(client, url, attributes, options)
+    Client.post(client, url, attributes, options)
     |> Response.parse(Domain)
   end
 
@@ -66,7 +66,7 @@ defmodule Dnsimple.Registrar do
   def transfer_domain_out(client, account_id, domain_name, options \\ []) do
     url = Client.versioned("/#{account_id}/registrar/domains/#{domain_name}/transfer_out")
 
-    Client.post2(client, url, _body = [], options)
+    Client.post(client, url, _body = [], options)
     |> Response.parse(nil)
   end
 
@@ -80,7 +80,7 @@ defmodule Dnsimple.Registrar do
   def enable_auto_renewal(client, account_id, domain_name, options \\ []) do
     url = Client.versioned("/#{account_id}/registrar/domains/#{domain_name}/auto_renewal")
 
-    Client.put2(client, url, options)
+    Client.put(client, url, options)
     |> Response.parse(nil)
   end
 
@@ -93,7 +93,7 @@ defmodule Dnsimple.Registrar do
   def disable_auto_renewal(client, account_id, domain_name, options \\ []) do
     url = Client.versioned("/#{account_id}/registrar/domains/#{domain_name}/auto_renewal")
 
-    Client.delete2(client, url, options)
+    Client.delete(client, url, options)
     |> Response.parse(nil)
   end
 
@@ -107,7 +107,7 @@ defmodule Dnsimple.Registrar do
   def whois_privacy(client, account_id, domain_name, options \\ []) do
     url = Client.versioned("/#{account_id}/registrar/domains/#{domain_name}/whois_privacy")
 
-    Client.get2(client, url, options)
+    Client.get(client, url, options)
     |> Response.parse(WhoisPrivacy)
   end
 
@@ -120,7 +120,7 @@ defmodule Dnsimple.Registrar do
   def enable_whois_privacy(client, account_id, domain_name, options \\ []) do
     url = Client.versioned("/#{account_id}/registrar/domains/#{domain_name}/whois_privacy")
 
-    Client.put2(client, url, _body = [], options)
+    Client.put(client, url, _body = [], options)
     |> Response.parse(WhoisPrivacy)
   end
 
@@ -133,7 +133,7 @@ defmodule Dnsimple.Registrar do
   def disable_whois_privacy(client, account_id, domain_name, options \\ []) do
     url = Client.versioned("/#{account_id}/registrar/domains/#{domain_name}/whois_privacy")
 
-    Client.delete2(client, url, options)
+    Client.delete(client, url, options)
     |> Response.parse(WhoisPrivacy)
   end
 

--- a/lib/dnsimple/services.ex
+++ b/lib/dnsimple/services.ex
@@ -10,6 +10,7 @@ defmodule Dnsimple.Services do
   alias Dnsimple.Response
   alias Dnsimple.Service
 
+
   @doc """
   List applied services.
 

--- a/lib/dnsimple/services.ex
+++ b/lib/dnsimple/services.ex
@@ -7,7 +7,6 @@ defmodule Dnsimple.Services do
   """
 
   alias Dnsimple.Client
-  alias Dnsimple.ListOptions
   alias Dnsimple.Response
   alias Dnsimple.Service
 
@@ -18,8 +17,9 @@ defmodule Dnsimple.Services do
   """
   @spec applied_services(Client.t, String.t | integer, String.t | integer) :: Response.t
   def applied_services(client, account_id, domain_id, options \\ []) do
-    {headers, opts} = Client.headers(options)
-    Client.get(client, Client.versioned("/#{account_id}/domains/#{domain_id}/services"), headers, ListOptions.prepare(opts))
+    url = Client.versioned("/#{account_id}/domains/#{domain_id}/services")
+
+    Client.get_list(client, url, options)
     |> Response.parse(Service)
   end
 
@@ -30,8 +30,9 @@ defmodule Dnsimple.Services do
   """
   @spec apply_service(Client.t, String.t | integer, String.t | integer, String.t | integer) :: Response.t
   def apply_service(client, account_id, domain_id, service_id, options \\ []) do
-    {headers, opts} = Client.headers(options)
-    Client.post(client, Client.versioned("/#{account_id}/domains/#{domain_id}/services/#{service_id}"), nil, headers, opts)
+    url = Client.versioned("/#{account_id}/domains/#{domain_id}/services/#{service_id}")
+
+    Client.post2(client, url, _attributes = nil, options)
     |> Response.parse(nil)
   end
 
@@ -42,8 +43,10 @@ defmodule Dnsimple.Services do
   """
   @spec unapply_service(Client.t, String.t | integer, String.t | integer, String.t | integer) :: Response.t
   def unapply_service(client, account_id, domain_id, service_id, options \\ []) do
-    {headers, opts} = Client.headers(options)
-    Client.delete(client, Client.versioned("/#{account_id}/domains/#{domain_id}/services/#{service_id}"), headers, opts)
+    url = Client.versioned("/#{account_id}/domains/#{domain_id}/services/#{service_id}")
+
+    Client.delete2(client, url, options)
     |> Response.parse(nil)
   end
+
 end

--- a/lib/dnsimple/services.ex
+++ b/lib/dnsimple/services.ex
@@ -6,6 +6,7 @@ defmodule Dnsimple.Services do
   @see https://developer.dnsimple.com/v2/services/domains/
   """
 
+  alias Dnsimple.List
   alias Dnsimple.Client
   alias Dnsimple.Response
   alias Dnsimple.Service
@@ -20,7 +21,7 @@ defmodule Dnsimple.Services do
   def applied_services(client, account_id, domain_id, options \\ []) do
     url = Client.versioned("/#{account_id}/domains/#{domain_id}/services")
 
-    Client.get_list(client, url, options)
+    List.get(client, url, options)
     |> Response.parse(Service)
   end
 

--- a/lib/dnsimple/services.ex
+++ b/lib/dnsimple/services.ex
@@ -32,7 +32,7 @@ defmodule Dnsimple.Services do
   def apply_service(client, account_id, domain_id, service_id, options \\ []) do
     url = Client.versioned("/#{account_id}/domains/#{domain_id}/services/#{service_id}")
 
-    Client.post2(client, url, _attributes = nil, options)
+    Client.post(client, url, _attributes = nil, options)
     |> Response.parse(nil)
   end
 
@@ -45,7 +45,7 @@ defmodule Dnsimple.Services do
   def unapply_service(client, account_id, domain_id, service_id, options \\ []) do
     url = Client.versioned("/#{account_id}/domains/#{domain_id}/services/#{service_id}")
 
-    Client.delete2(client, url, options)
+    Client.delete(client, url, options)
     |> Response.parse(nil)
   end
 

--- a/lib/dnsimple/webhooks.ex
+++ b/lib/dnsimple/webhooks.ex
@@ -33,7 +33,7 @@ defmodule Dnsimple.Webhooks do
   def create_webhook(client, account_id, attributes, options \\ []) do
     url = Client.versioned("/#{account_id}/webhooks")
 
-    Client.post2(client, url, attributes, options)
+    Client.post(client, url, attributes, options)
     |> Response.parse(Webhook)
   end
 
@@ -46,7 +46,7 @@ defmodule Dnsimple.Webhooks do
   def webhook(client, account_id, webhook_id, options \\ []) do
     url = Client.versioned("/#{account_id}/webhooks/#{webhook_id}")
 
-    Client.get2(client, url, options)
+    Client.get(client, url, options)
     |> Response.parse(Webhook)
   end
 
@@ -59,7 +59,7 @@ defmodule Dnsimple.Webhooks do
   def delete_webhook(client, account_id, webhook_id, options \\ []) do
     url = Client.versioned("/#{account_id}/webhooks/#{webhook_id}")
 
-    Client.delete2(client, url, options)
+    Client.delete(client, url, options)
     |> Response.parse(nil)
   end
 

--- a/lib/dnsimple/webhooks.ex
+++ b/lib/dnsimple/webhooks.ex
@@ -7,7 +7,6 @@ defmodule Dnsimple.Webhooks do
   """
 
   alias Dnsimple.Client
-  alias Dnsimple.ListOptions
   alias Dnsimple.Response
   alias Dnsimple.Webhook
 
@@ -19,8 +18,9 @@ defmodule Dnsimple.Webhooks do
   """
   @spec webhooks(Client.t, String.t | integer) :: Response.t
   def webhooks(client, account_id, options \\ []) do
-    {headers, opts} = Client.headers(options)
-    Client.get(client, Client.versioned("/#{account_id}/webhooks"), headers, ListOptions.prepare(opts))
+    url = Client.versioned("/#{account_id}/webhooks")
+
+    Client.get_list(client, url, options)
     |> Response.parse(Webhook)
   end
 
@@ -31,8 +31,9 @@ defmodule Dnsimple.Webhooks do
   """
   @spec create_webhook(Client.t, String.t | integer, map, Keyword.t) :: Response.t
   def create_webhook(client, account_id, attributes, options \\ []) do
-    {headers, opts} = Client.headers(options)
-    Client.post(client, Client.versioned("/#{account_id}/webhooks"), attributes, headers, opts)
+    url = Client.versioned("/#{account_id}/webhooks")
+
+    Client.post2(client, url, attributes, options)
     |> Response.parse(Webhook)
   end
 
@@ -43,8 +44,9 @@ defmodule Dnsimple.Webhooks do
   """
   @spec webhook(Client.t, String.t | integer, String.t | integer, Keyword.t) :: Response.t
   def webhook(client, account_id, webhook_id, options \\ []) do
-    {headers, opts} = Client.headers(options)
-    Client.get(client, Client.versioned("/#{account_id}/webhooks/#{webhook_id}"), headers, opts)
+    url = Client.versioned("/#{account_id}/webhooks/#{webhook_id}")
+
+    Client.get2(client, url, options)
     |> Response.parse(Webhook)
   end
 
@@ -55,8 +57,10 @@ defmodule Dnsimple.Webhooks do
   """
   @spec delete_webhook(Client.t, String.t | integer, String.t | integer, Keyword.t) :: Response.t
   def delete_webhook(client, account_id, webhook_id, options \\ []) do
-    {headers, opts} = Client.headers(options)
-    Client.delete(client, Client.versioned("/#{account_id}/webhooks/#{webhook_id}"), headers, opts)
+    url = Client.versioned("/#{account_id}/webhooks/#{webhook_id}")
+
+    Client.delete2(client, url, options)
     |> Response.parse(nil)
   end
+
 end

--- a/lib/dnsimple/webhooks.ex
+++ b/lib/dnsimple/webhooks.ex
@@ -6,6 +6,7 @@ defmodule Dnsimple.Webhooks do
   See https://developer.dnsimple.com/v2/webhooks/
   """
 
+  alias Dnsimple.List
   alias Dnsimple.Client
   alias Dnsimple.Response
   alias Dnsimple.Webhook
@@ -20,7 +21,7 @@ defmodule Dnsimple.Webhooks do
   def webhooks(client, account_id, options \\ []) do
     url = Client.versioned("/#{account_id}/webhooks")
 
-    Client.get_list(client, url, options)
+    List.get(client, url, options)
     |> Response.parse(Webhook)
   end
 

--- a/lib/dnsimple/zones.ex
+++ b/lib/dnsimple/zones.ex
@@ -7,6 +7,7 @@ defmodule Dnsimple.Zones do
   See https://developer.dnsimple.com/v2/zones/records/
   """
 
+  alias Dnsimple.List
   alias Dnsimple.Client
   alias Dnsimple.Response
   alias Dnsimple.Zone
@@ -22,7 +23,7 @@ defmodule Dnsimple.Zones do
   def zones(client, account_id, options \\ []) do
     url = Client.versioned("/#{account_id}/zones")
 
-    Client.get_list(client, url, options)
+    List.get(client, url, options)
     |> Response.parse(Zone)
   end
 
@@ -49,7 +50,7 @@ defmodule Dnsimple.Zones do
   def records(client, account_id, zone_name, options \\ []) do
     url = Client.versioned("/#{account_id}/zones/#{zone_name}/records")
 
-    Client.get_list(client, url, options)
+    List.get(client, url, options)
     |> Response.parse(ZoneRecord)
   end
 

--- a/lib/dnsimple/zones.ex
+++ b/lib/dnsimple/zones.ex
@@ -1,8 +1,17 @@
 defmodule Dnsimple.Zones do
+  @moduledoc """
+  Handles communication with zone and zone record related
+  methods of the DNSimple API.
+
+  See https://developer.dnsimple.com/v2/zones/
+  See https://developer.dnsimple.com/v2/zones/records/
+  """
+
   alias Dnsimple.Client
   alias Dnsimple.Response
   alias Dnsimple.Zone
   alias Dnsimple.ZoneRecord
+
 
   @doc """
   Lists the zones in the account.

--- a/lib/dnsimple/zones.ex
+++ b/lib/dnsimple/zones.ex
@@ -26,7 +26,7 @@ defmodule Dnsimple.Zones do
   def zone(client, account_id, zone_name, options \\ []) do
     url = Client.versioned("/#{account_id}/zones/#{zone_name}")
 
-    Client.get2(client, url, options)
+    Client.get(client, url, options)
     |> Response.parse(Zone)
   end
 
@@ -53,7 +53,7 @@ defmodule Dnsimple.Zones do
   def create_record(client, account_id, zone_name, attributes, options \\ []) do
     url = Client.versioned("/#{account_id}/zones/#{zone_name}/records")
 
-    Client.post2(client, url, attributes, options)
+    Client.post(client, url, attributes, options)
     |> Response.parse(ZoneRecord)
   end
 
@@ -66,7 +66,7 @@ defmodule Dnsimple.Zones do
   def record(client, account_id, zone_name, record_id, options \\ []) do
     url = Client.versioned("/#{account_id}/zones/#{zone_name}/records/#{record_id}")
 
-    Client.get2(client, url, options)
+    Client.get(client, url, options)
     |> Response.parse(Dnsimple.ZoneRecord)
   end
 
@@ -79,7 +79,7 @@ defmodule Dnsimple.Zones do
   def update_record(client, account_id, zone_name, record_id, attributes, options \\ []) do
     url = Client.versioned("/#{account_id}/zones/#{zone_name}/records/#{record_id}")
 
-    Client.patch2(client, url, attributes, options)
+    Client.patch(client, url, attributes, options)
     |> Response.parse(ZoneRecord)
   end
 
@@ -92,7 +92,7 @@ defmodule Dnsimple.Zones do
   def delete_record(client, account_id, zone_name, record_id, options \\ []) do
     url = Client.versioned("/#{account_id}/zones/#{zone_name}/records/#{record_id}")
 
-    Client.delete2(client, url, options)
+    Client.delete(client, url, options)
     |> Response.parse(nil)
   end
 

--- a/lib/dnsimple/zones.ex
+++ b/lib/dnsimple/zones.ex
@@ -1,7 +1,8 @@
 defmodule Dnsimple.Zones do
   alias Dnsimple.Client
-  alias Dnsimple.ListOptions
   alias Dnsimple.Response
+  alias Dnsimple.Zone
+  alias Dnsimple.ZoneRecord
 
   @doc """
   Lists the zones in the account.
@@ -11,10 +12,9 @@ defmodule Dnsimple.Zones do
   @spec zones(Client.t, String.t, Keyword.t) :: Response.t
   def zones(client, account_id, options \\ []) do
     url = Client.versioned("/#{account_id}/zones")
-    {headers, opts} = Client.headers(options)
 
-    Client.get(client, url, headers, ListOptions.prepare(opts))
-      |> Response.parse(Dnsimple.Zone)
+    Client.get_list(client, url, options)
+    |> Response.parse(Zone)
   end
 
   @doc """
@@ -25,11 +25,11 @@ defmodule Dnsimple.Zones do
   @spec zone(Client.t, String.t, String.t, Keyword.t) :: Response.t
   def zone(client, account_id, zone_name, options \\ []) do
     url = Client.versioned("/#{account_id}/zones/#{zone_name}")
-    {headers, opts} = Client.headers(options)
 
-    Client.get(client, url, headers, opts)
-      |> Response.parse(Dnsimple.Zone)
+    Client.get2(client, url, options)
+    |> Response.parse(Zone)
   end
+
 
   @doc """
   Lists the records in a zone.
@@ -39,10 +39,9 @@ defmodule Dnsimple.Zones do
   @spec records(Client.t, String.t, String.t, Keyword.t) :: Response.t
   def records(client, account_id, zone_name, options \\ []) do
     url = Client.versioned("/#{account_id}/zones/#{zone_name}/records")
-    {headers, opts} = Client.headers(options)
 
-    Client.get(client, url, headers, ListOptions.prepare(opts))
-      |> Response.parse(Dnsimple.ZoneRecord)
+    Client.get_list(client, url, options)
+    |> Response.parse(ZoneRecord)
   end
 
   @doc """
@@ -53,10 +52,9 @@ defmodule Dnsimple.Zones do
   @spec create_record(Client.t, String.t, String.t, Keyword.t, Keyword.t) :: Response.t
   def create_record(client, account_id, zone_name, attributes, options \\ []) do
     url = Client.versioned("/#{account_id}/zones/#{zone_name}/records")
-    {headers, opts} = Client.headers(options)
 
-    Client.post(client, url, attributes, headers, opts)
-      |> Response.parse(Dnsimple.ZoneRecord)
+    Client.post2(client, url, attributes, options)
+    |> Response.parse(ZoneRecord)
   end
 
   @doc """
@@ -67,10 +65,9 @@ defmodule Dnsimple.Zones do
   @spec record(Client.t, String.t, String.t, integer, Keyword.t) :: Response.t
   def record(client, account_id, zone_name, record_id, options \\ []) do
     url = Client.versioned("/#{account_id}/zones/#{zone_name}/records/#{record_id}")
-    {headers, opts} = Client.headers(options)
 
-    Client.get(client, url, headers, opts)
-      |> Response.parse(Dnsimple.ZoneRecord)
+    Client.get2(client, url, options)
+    |> Response.parse(Dnsimple.ZoneRecord)
   end
 
   @doc """
@@ -81,10 +78,9 @@ defmodule Dnsimple.Zones do
   @spec update_record(Client.t, String.t, String.t, integer, Keyword.t, Keyword.t) :: Response.t
   def update_record(client, account_id, zone_name, record_id, attributes, options \\ []) do
     url = Client.versioned("/#{account_id}/zones/#{zone_name}/records/#{record_id}")
-    {headers, opts} = Client.headers(options)
 
-    Client.patch(client, url, attributes, headers, opts)
-      |> Response.parse(Dnsimple.ZoneRecord)
+    Client.patch2(client, url, attributes, options)
+    |> Response.parse(ZoneRecord)
   end
 
   @doc """
@@ -95,10 +91,9 @@ defmodule Dnsimple.Zones do
   @spec delete_record(Client.t, String.t, String.t, integer, Keyword.t) :: Response.t
   def delete_record(client, account_id, zone_name, record_id, options \\ []) do
     url = Client.versioned("/#{account_id}/zones/#{zone_name}/records/#{record_id}")
-    {headers, opts} = Client.headers(options)
 
-    Client.delete(client, url, headers, opts)
-      |> Response.parse(nil)
+    Client.delete2(client, url, options)
+    |> Response.parse(nil)
   end
 
 end

--- a/test/dnsimple_test.exs
+++ b/test/dnsimple_test.exs
@@ -1,25 +1,34 @@
-defmodule DnsimpleTest do
+defmodule Dnsimple.TestOptionsTest do
   use ExUnit.Case, async: true
-  doctest Dnsimple
 
-  test "empty list options results in empty params list" do
-    assert Dnsimple.ListOptions.prepare([]) == []
-  end
+  describe ".prepare" do
+    test "empty list options results in empty params list" do
+      assert Dnsimple.ListOptions.prepare([]) == []
+    end
 
-  test "list options include filter if it is present" do
-    assert Dnsimple.ListOptions.prepare([filter: [name_like: "example"]]) == [params: [name_like: "example"]]
-  end
+    test "includes filter if present" do
+      assert Dnsimple.ListOptions.prepare([filter: [name_like: "example"]]) == [params: [name_like: "example"]]
+    end
 
-  test "list options include sort if it is present" do
-    assert Dnsimple.ListOptions.prepare([sort: "foo:asc"]) == [params: [sort: "foo:asc"]]
-  end
+    test "includes sort if it present" do
+      assert Dnsimple.ListOptions.prepare([sort: "foo:asc"]) == [params: [sort: "foo:asc"]]
+    end
 
-  test "list options include page if it is present" do
-    assert Dnsimple.ListOptions.prepare([page: 1]) == [params: [page: 1]]
-  end
+    test "includes page if it present" do
+      assert Dnsimple.ListOptions.prepare([page: 1]) == [params: [page: 1]]
+    end
 
-  test "list options include per page if it is present" do
-    assert Dnsimple.ListOptions.prepare([per_page: 1]) == [params: [per_page: 1]]
+    test "includes per page if present" do
+      assert Dnsimple.ListOptions.prepare([per_page: 1]) == [params: [per_page: 1]]
+    end
+
+    test "combines options correctly" do
+      assert Dnsimple.ListOptions.prepare([per_page: 1, sort: "foo:asc"]) == [params: [per_page: 1, sort: "foo:asc"]]
+    end
+
+    test "mantains other options" do
+      assert Dnsimple.ListOptions.prepare([sort: "foo:asc", other: "foo"]) == [params: [sort: "foo:asc"], other: "foo"]
+    end
   end
 
 end

--- a/test/dnsimple_test.exs
+++ b/test/dnsimple_test.exs
@@ -6,6 +6,10 @@ defmodule Dnsimple.TestOptionsTest do
       assert Dnsimple.ListOptions.prepare([]) == []
     end
 
+    test "empty list options with other options results in no params list" do
+      assert Dnsimple.ListOptions.prepare([headers: [{"X-Header", "X-Value"}]]) == [headers: [{"X-Header", "X-Value"}]]
+    end
+
     test "includes filter if present" do
       assert Dnsimple.ListOptions.prepare([filter: [name_like: "example"]]) == [params: [name_like: "example"]]
     end

--- a/test/dnsimple_test.exs
+++ b/test/dnsimple_test.exs
@@ -1,37 +1,37 @@
 defmodule Dnsimple.TestOptionsTest do
   use ExUnit.Case, async: true
 
-  describe ".prepare" do
+  describe ".format" do
     test "empty list options results in empty params list" do
-      assert Dnsimple.ListOptions.prepare([]) == []
+      assert Dnsimple.List.format([]) == []
     end
 
     test "empty list options with other options results in no params list" do
-      assert Dnsimple.ListOptions.prepare([headers: [{"X-Header", "X-Value"}]]) == [headers: [{"X-Header", "X-Value"}]]
+      assert Dnsimple.List.format([headers: [{"X-Header", "X-Value"}]]) == [headers: [{"X-Header", "X-Value"}]]
     end
 
     test "includes filter if present" do
-      assert Dnsimple.ListOptions.prepare([filter: [name_like: "example"]]) == [params: [name_like: "example"]]
+      assert Dnsimple.List.format([filter: [name_like: "example"]]) == [params: [name_like: "example"]]
     end
 
     test "includes sort if it present" do
-      assert Dnsimple.ListOptions.prepare([sort: "foo:asc"]) == [params: [sort: "foo:asc"]]
+      assert Dnsimple.List.format([sort: "foo:asc"]) == [params: [sort: "foo:asc"]]
     end
 
     test "includes page if it present" do
-      assert Dnsimple.ListOptions.prepare([page: 1]) == [params: [page: 1]]
+      assert Dnsimple.List.format([page: 1]) == [params: [page: 1]]
     end
 
     test "includes per page if present" do
-      assert Dnsimple.ListOptions.prepare([per_page: 1]) == [params: [per_page: 1]]
+      assert Dnsimple.List.format([per_page: 1]) == [params: [per_page: 1]]
     end
 
     test "combines options correctly" do
-      assert Dnsimple.ListOptions.prepare([per_page: 1, sort: "foo:asc"]) == [params: [per_page: 1, sort: "foo:asc"]]
+      assert Dnsimple.List.format([per_page: 1, sort: "foo:asc"]) == [params: [per_page: 1, sort: "foo:asc"]]
     end
 
     test "mantains other options" do
-      assert Dnsimple.ListOptions.prepare([sort: "foo:asc", other: "foo"]) == [params: [sort: "foo:asc"], other: "foo"]
+      assert Dnsimple.List.format([sort: "foo:asc", other: "foo"]) == [params: [sort: "foo:asc"], other: "foo"]
     end
   end
 

--- a/test/dnsimple_test.exs
+++ b/test/dnsimple_test.exs
@@ -1,37 +1,39 @@
-defmodule Dnsimple.TestOptionsTest do
+defmodule Dnsimple.ListTest do
   use ExUnit.Case, async: true
+
+  alias Dnsimple.List
 
   describe ".format" do
     test "empty list options results in empty params list" do
-      assert Dnsimple.List.format([]) == []
+      assert List.format([]) == []
     end
 
     test "empty list options with other options results in no params list" do
-      assert Dnsimple.List.format([headers: [{"X-Header", "X-Value"}]]) == [headers: [{"X-Header", "X-Value"}]]
+      assert List.format([headers: [{"X-Header", "X-Value"}]]) == [headers: [{"X-Header", "X-Value"}]]
     end
 
     test "includes filter if present" do
-      assert Dnsimple.List.format([filter: [name_like: "example"]]) == [params: [name_like: "example"]]
+      assert List.format([filter: [name_like: "example"]]) == [params: [name_like: "example"]]
     end
 
     test "includes sort if it present" do
-      assert Dnsimple.List.format([sort: "foo:asc"]) == [params: [sort: "foo:asc"]]
+      assert List.format([sort: "foo:asc"]) == [params: [sort: "foo:asc"]]
     end
 
     test "includes page if it present" do
-      assert Dnsimple.List.format([page: 1]) == [params: [page: 1]]
+      assert List.format([page: 1]) == [params: [page: 1]]
     end
 
     test "includes per page if present" do
-      assert Dnsimple.List.format([per_page: 1]) == [params: [per_page: 1]]
+      assert List.format([per_page: 1]) == [params: [per_page: 1]]
     end
 
     test "combines options correctly" do
-      assert Dnsimple.List.format([per_page: 1, sort: "foo:asc"]) == [params: [per_page: 1, sort: "foo:asc"]]
+      assert List.format([per_page: 1, sort: "foo:asc"]) == [params: [per_page: 1, sort: "foo:asc"]]
     end
 
     test "mantains other options" do
-      assert Dnsimple.List.format([sort: "foo:asc", other: "foo"]) == [params: [sort: "foo:asc"], other: "foo"]
+      assert List.format([sort: "foo:asc", other: "foo"]) == [params: [sort: "foo:asc"], other: "foo"]
     end
   end
 


### PR DESCRIPTION
Headers had to be explicitly processed in every single function that issued an HTTP request. This PR removes that duplication by pushing the header processing down to the HTTP client level.

Other changes in this PR:

- Re-writes `ListOptions.prepare` making the algorithm more clear and adding missing tests.
- Unifies function structure by extracting `url` to a local variable everywhere.
- Refactors some HTTP client internals.
- Introduces `get_list` as a way to remove duplication in listing methods. All of them where calling `ListOptions.prepare` so I extracted a separate function that does this.