### PR TITLE
Starting HTTPoison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 
 #### master
 
-- NEW: Added support for contact endpoints(GH-38)
+- NEW: Added function to start OTP app (GH-45)
+
+- NEW: Added support for contact endpoints (GH-38)
 - NEW: Added reset domain token endpoint support (GH-37)
 - NEW: Added support for accounts (GH-29)
 - NEW: Added support for filtering and sorting (GH-19)

--- a/README.md
+++ b/README.md
@@ -14,17 +14,57 @@ An Elixir client for the [DNSimple API v2](https://developer.dnsimple.com/v2/).
 [![Build Status](https://travis-ci.org/dnsimple/dnsimple-elixir.svg?branch=master)](https://travis-ci.org/dnsimple/dnsimple-elixir)
 
 
+
+## Installation
+
+You will have to add the `dnsimple` app to your `mix.exs` file as a dependency:
+
+```elixir
+def deps do
+  [
+    #...
+    {:dnsimple, "~> 0.9"}
+  ]
+end
+```
+
+And then add it to the list of applications that should be started:
+
+```elixir
+def application do
+  [applications: [ :dnsimple, ... ]]
+end
+```
+
+
 ## Usage
+
+### From iex
 
 ```elixir
 # Create a client passing the proper settings
 iex> client = %Dnsimple.Client{access_token: "TOKEN", base_url: "https://api.sandbox.dnsimple.com/"}
 
 # Check the login
-iex> Dnsimple.Identity.whoami(client)
-%{"account" => %{"created_at" => "2014-05-19T14:20:32.263Z",
-    "email" => "example-account@example.com", "id" => 1,
-    "updated_at" => "2015-04-01T10:07:47.559Z"}, "user" => nil}
+iex> {:ok, response} =Dnsimple.Identity.whoami(client)
+iex> response.data
+#=> %{"account" => %{"created_at" => "2014-05-19T14:20:32.263Z",
+      "email" => "example-account@example.com", "id" => 1,
+      "updated_at" => "2015-04-01T10:07:47.559Z"}, "user" => nil}
+```
+
+
+### From an .exs file
+
+```elixir
+# Start Dnsimple app
+Dnsimple.start
+
+# Create a client passing the proper settings
+client = %Dnsimple.Client{access_token: "TOKEN", base_url: "https://api.sandbox.dnsimple.com/"}
+
+# Check the login
+Dnsimple.Identity.whoami(client)
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ end
 iex> client = %Dnsimple.Client{access_token: "TOKEN", base_url: "https://api.sandbox.dnsimple.com/"}
 
 # Check the login
-iex> {:ok, response} =Dnsimple.Identity.whoami(client)
+iex> {:ok, response} = Dnsimple.Identity.whoami(client)
 iex> response.data
 # => %{"account" => %{"created_at" => "2014-05-19T14:20:32.263Z",
 # =>   "email" => "example-account@example.com", "id" => 1,

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ iex> client = %Dnsimple.Client{access_token: "TOKEN", base_url: "https://api.san
 # Check the login
 iex> {:ok, response} =Dnsimple.Identity.whoami(client)
 iex> response.data
-#=> %{"account" => %{"created_at" => "2014-05-19T14:20:32.263Z",
-      "email" => "example-account@example.com", "id" => 1,
-      "updated_at" => "2015-04-01T10:07:47.559Z"}, "user" => nil}
+# => %{"account" => %{"created_at" => "2014-05-19T14:20:32.263Z",
+# =>   "email" => "example-account@example.com", "id" => 1,
+# =>   "updated_at" => "2015-04-01T10:07:47.559Z"}, "user" => nil}
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@ You will have to add the `dnsimple` app to your `mix.exs` file as a dependency:
 ```elixir
 def deps do
   [
-    #...
-    {:dnsimple, "~> 0.9"}
+    {:dnsimple, "~> 0.9"}, #...
   ]
 end
 ```
@@ -32,7 +31,9 @@ And then add it to the list of applications that should be started:
 
 ```elixir
 def application do
-  [applications: [ :dnsimple, ... ]]
+  [applications: [
+    :dnsimple, #...
+  ]]
 end
 ```
 

--- a/lib/dnsimple.ex
+++ b/lib/dnsimple.ex
@@ -1,5 +1,8 @@
 defmodule Dnsimple do
 
+  def start, do: :application.ensure_all_started(:httpoison)
+
+
   defmodule Error do
     def decode(body) do
       Poison.decode!(body)


### PR DESCRIPTION
Closes #14

Right now to use the Dnsimple library starting HTTPoison in some way or the other was required.

This PR defines a `Dnsimple.start` function that will be responsible of starting any dependent app so we don't expose our dependencies nor make users responsible of starting them.