### PR TITLE
Correctly handle service settings

### DIFF
--- a/lib/dnsimple/services.ex
+++ b/lib/dnsimple/services.ex
@@ -94,13 +94,13 @@ defmodule Dnsimple.Services do
 
     Dnsimple.Services.apply_service(client, account_id = 1010, domain_id = "example.com", service_id = 12)
     Dnsimple.Services.apply_service(client, account_id = 1010, domain_id = "example.com", service_id = 27, %{
-      setting_name: "setting value"
+      %{settings: %{setting_name: "setting value"}}
     })
 
   """
   @spec apply_service(Client.t, String.t | integer, String.t | integer, String.t | integer, Map.t, Keyword.t) :: Response.t
   def apply_service(client, account_id, domain_id, service_id, settings \\ %{}, options \\ []) do
-    url = Client.versioned("/#{account_id}/domains/#{domain_id}/services/#{service_id}")
+    url      = Client.versioned("/#{account_id}/domains/#{domain_id}/services/#{service_id}")
 
     Client.post(client, url, settings, options)
     |> Response.parse(nil)

--- a/lib/dnsimple/services.ex
+++ b/lib/dnsimple/services.ex
@@ -93,6 +93,9 @@ defmodule Dnsimple.Services do
     client = %Dnsimple.Client{access_token: "a1b2c3d4"}
 
     Dnsimple.Services.apply_service(client, account_id = 1010, domain_id = "example.com", service_id = 12)
+    Dnsimple.Services.apply_service(client, account_id = 1010, domain_id = "example.com", service_id = 27, %{
+      setting_name: "setting value"
+    })
 
   """
   @spec apply_service(Client.t, String.t | integer, String.t | integer, String.t | integer, Map.t, Keyword.t) :: Response.t

--- a/lib/dnsimple/services.ex
+++ b/lib/dnsimple/services.ex
@@ -100,7 +100,7 @@ defmodule Dnsimple.Services do
   """
   @spec apply_service(Client.t, String.t | integer, String.t | integer, String.t | integer, Map.t, Keyword.t) :: Response.t
   def apply_service(client, account_id, domain_id, service_id, settings \\ %{}, options \\ []) do
-    url      = Client.versioned("/#{account_id}/domains/#{domain_id}/services/#{service_id}")
+    url = Client.versioned("/#{account_id}/domains/#{domain_id}/services/#{service_id}")
 
     Client.post(client, url, settings, options)
     |> Response.parse(nil)

--- a/lib/dnsimple/services.ex
+++ b/lib/dnsimple/services.ex
@@ -95,11 +95,11 @@ defmodule Dnsimple.Services do
     Dnsimple.Services.apply_service(client, account_id = 1010, domain_id = "example.com", service_id = 12)
 
   """
-  @spec apply_service(Client.t, String.t | integer, String.t | integer, String.t | integer, Keyword.t) :: Response.t
-  def apply_service(client, account_id, domain_id, service_id, options \\ []) do
+  @spec apply_service(Client.t, String.t | integer, String.t | integer, String.t | integer, Map.t, Keyword.t) :: Response.t
+  def apply_service(client, account_id, domain_id, service_id, settings \\ %{}, options \\ []) do
     url = Client.versioned("/#{account_id}/domains/#{domain_id}/services/#{service_id}")
 
-    Client.post(client, url, Client.empty_body, options)
+    Client.post(client, url, settings, options)
     |> Response.parse(nil)
   end
 

--- a/test/dnsimple/services_test.exs
+++ b/test/dnsimple/services_test.exs
@@ -143,7 +143,7 @@ defmodule Dnsimple.ServicesTest do
       url      = "#{@client.base_url}/v2/#{@account_id}/domains/#{@domain_id}/services/1"
       method   = "post"
       fixture  = "applyService/success.http"
-      settings = %{name: "foobar"}
+      settings = %{settings: %{name: "value"}}
       body     = Poison.encode!(settings)
 
       use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url, request_body: body) do

--- a/test/dnsimple/services_test.exs
+++ b/test/dnsimple/services_test.exs
@@ -140,12 +140,14 @@ defmodule Dnsimple.ServicesTest do
 
   describe ".apply_service" do
     test "applies the service and returns an empty Dnsimple.Response" do
-      url     = "#{@client.base_url}/v2/#{@account_id}/domains/#{@domain_id}/services/1"
-      method  = "post"
-      fixture = "applyService/success.http"
+      url      = "#{@client.base_url}/v2/#{@account_id}/domains/#{@domain_id}/services/1"
+      method   = "post"
+      fixture  = "applyService/success.http"
+      settings = %{name: "foobar"}
+      body     = Poison.encode!(settings)
 
-      use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url) do
-        {:ok, response} = @module.apply_service(@client, @account_id, @domain_id, _service_id = 1)
+      use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url, request_body: body) do
+        {:ok, response} = @module.apply_service(@client, @account_id, @domain_id, _service_id = 1, settings)
         assert response.__struct__ == Dnsimple.Response
         assert response.data == nil
       end


### PR DESCRIPTION
Closes #76 

Adds an argument to the `Services.apply_service` function specific for the settings that defaults to an empty map. This map is sent as the request body instead of sending an empty one.