### PR TITLE
`auth_code` vs `auth_info`

### DIFF
--- a/test/dnsimple/registrar_test.exs
+++ b/test/dnsimple/registrar_test.exs
@@ -91,7 +91,7 @@ defmodule Dnsimple.RegistrarTest do
       url         = "#{@client.base_url}/v2/#{@account_id}/registrar/domains/example.com/transfer"
       method      = "post"
       fixture     = "transferDomain/success.http"
-      attributes  = %{registrant_id: 10, auth_info: "x1y2z3", auto_renew: false, privacy: false}
+      attributes  = %{registrant_id: 10, auth_code: "x1y2z3", auto_renew: false, privacy: false}
       {:ok, body} = Poison.encode(attributes)
 
       use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url, request_body: body) do


### PR DESCRIPTION
Closes #79 

The tests had it as `auth_info`, but the docs of `Registrar.transfer_domain` did have it as `auth_code`.