### PR TITLE
add request logging (debug)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### master
 
+- NEW: Added request logging (GH-81)
 - NEW: Added support for collaborator endpoints (GH-74)
 - NEW: Added support to zone records regions (GH-72)
 - NEW: Added new attributes to TLDs (GH-69)

--- a/config/config.exs
+++ b/config/config.exs
@@ -18,8 +18,7 @@ use Mix.Config
 #
 # Or configure a 3rd-party app:
 #
-#     config :logger, level: :info
-#
+config :logger, level: :info
 
 # It is also possible to import configuration files, relative to this
 # directory. For example, you can emulate configuration per environment

--- a/lib/dnsimple.ex
+++ b/lib/dnsimple.ex
@@ -1,4 +1,5 @@
 defmodule Dnsimple do
+  require Logger
 
   def start, do: :application.ensure_all_started(:httpoison)
 
@@ -115,6 +116,8 @@ defmodule Dnsimple do
       {headers, options} = split_headers_options(client, all_options)
       {headers, body}    = process_request_body(headers, body)
       base_options       = [recv_timeout: 30000]
+
+      Logger.debug("[DNSimple-API] #{method} #{url(client, url)}") # log request
 
       HTTPoison.request!(method, url(client, url), body, headers, Keyword.merge(base_options, options))
       |> check_response

--- a/lib/dnsimple.ex
+++ b/lib/dnsimple.ex
@@ -117,7 +117,7 @@ defmodule Dnsimple do
       {headers, body}    = process_request_body(headers, body)
       base_options       = [recv_timeout: 30000]
 
-      Logger.debug("[DNSimple-API] #{String.upcase(Atom.to_string(method))} #{url(client, url)}")
+      Logger.debug("[dnsimple] #{String.upcase(Atom.to_string(method))} #{url(client, url)}")
 
       HTTPoison.request!(method, url(client, url), body, headers, Keyword.merge(base_options, options))
       |> check_response

--- a/lib/dnsimple.ex
+++ b/lib/dnsimple.ex
@@ -117,7 +117,7 @@ defmodule Dnsimple do
       {headers, body}    = process_request_body(headers, body)
       base_options       = [recv_timeout: 30000]
 
-      Logger.debug("[DNSimple-API] #{method} #{url(client, url)}") # log request
+      Logger.debug("[DNSimple-API] #{String.upcase(Atom.to_string(method))} #{url(client, url)}")
 
       HTTPoison.request!(method, url(client, url), body, headers, Keyword.merge(base_options, options))
       |> check_response

--- a/lib/dnsimple.ex
+++ b/lib/dnsimple.ex
@@ -117,7 +117,7 @@ defmodule Dnsimple do
       {headers, body}    = process_request_body(headers, body)
       base_options       = [recv_timeout: 30000]
 
-      Logger.debug("[dnsimple] #{String.upcase(Atom.to_string(method))} #{url(client, url)}")
+      Logger.debug("[dnsimple] #{format_http_method(method)} #{url(client, url)}")
 
       HTTPoison.request!(method, url(client, url), body, headers, Keyword.merge(base_options, options))
       |> check_response
@@ -179,6 +179,9 @@ defmodule Dnsimple do
         _   -> {:error, RequestError.new(http_response)}
       end
     end
+
+    defp format_http_method(method) when is_atom(method), do: format_http_method(Atom.to_string(method))
+    defp format_http_method(method) when is_binary(method), do: String.upcase(method)
   end
 
 


### PR DESCRIPTION
This PR fixes #81

I think logging with log level `debug` might be the best option, so people can decide if they need debug information or not.