### PR TITLE
Remove aliases

### DIFF
--- a/lib/dnsimple/accounts.ex
+++ b/lib/dnsimple/accounts.ex
@@ -24,7 +24,4 @@ defmodule Dnsimple.Accounts do
     |> Response.parse(%{"data" => [%Account{}]})
   end
 
-  @spec accounts(Client.t) :: Response.t
-  defdelegate accounts(client), to: __MODULE__, as: :list_accounts
-
 end

--- a/lib/dnsimple/certificates.ex
+++ b/lib/dnsimple/certificates.ex
@@ -35,9 +35,6 @@ defmodule Dnsimple.Certificates do
     |> Response.parse(%{"data" => [%Certificate{}], "pagination" => %Response.Pagination{}})
   end
 
-  @spec certificates(Client.t, String.t | integer, String.t | integer, Keyword.t) :: Response.t
-  defdelegate certificates(client, account_id, domain_id, options \\ []), to: __MODULE__, as: :list_certificates
-
 
   @doc """
   Returns the certificate data.
@@ -60,9 +57,6 @@ defmodule Dnsimple.Certificates do
     Client.get(client, url, options)
     |> Response.parse(%{"data" => %Certificate{}})
   end
-
-  @spec certificate(Client.t, String.t | integer, String.t | integer, String.t | integer, Keyword.t) :: Response.t
-  defdelegate certificate(client, account_id, domain_id, certificate_id, options \\ []), to: __MODULE__, as: :get_certificate
 
 
   @doc """
@@ -109,8 +103,5 @@ defmodule Dnsimple.Certificates do
     Client.get(client, url, options)
     |> Response.parse(%{"data" => %Certificate{}})
   end
-
-  @spec certificate_private_key(Client.t, String.t | integer, String.t | integer, String.t | integer, Keyword.t) :: Response.t
-  defdelegate certificate_private_key(client, account_id, domain_id, certificate_id, options \\ []), to: __MODULE__, as: :get_certificate_private_key
 
 end

--- a/lib/dnsimple/contacts.ex
+++ b/lib/dnsimple/contacts.ex
@@ -23,9 +23,6 @@ defmodule Dnsimple.Contacts do
     |> Response.parse(%{"data" => [%Contact{}], "pagination" => %Response.Pagination{}})
   end
 
-  @spec contacts(Client.t, String.t | integer, Keyword.t) :: Response.t
-  defdelegate contacts(client, account_id, options \\ []), to: __MODULE__, as: :list_contacts
-
 
   @doc """
   Gets a contact in the account.
@@ -39,9 +36,6 @@ defmodule Dnsimple.Contacts do
     Client.get(client, url, options)
     |> Response.parse(%{"data" => %Contact{}})
   end
-
-  @spec contact(Client.t, String.t | integer, String.t | integer, Keyword.t) :: Response.t
-  defdelegate contact(client, account_id, contact_id, options \\ []), to: __MODULE__, as: :get_contact
 
 
   @doc """

--- a/lib/dnsimple/domains.ex
+++ b/lib/dnsimple/domains.ex
@@ -36,9 +36,6 @@ defmodule Dnsimple.Domains do
     |> Response.parse(%{"data" => [%Domain{}], "pagination" => %Response.Pagination{}})
   end
 
-  @spec domains(Client.t, String.t | integer) :: Response.t
-  defdelegate domains(client, account_id, options \\ []), to: __MODULE__, as: :list_domains
-
 
   @doc """
   List all domains from the account.
@@ -80,9 +77,6 @@ defmodule Dnsimple.Domains do
     Client.get(client, url, options)
     |> Response.parse(%{"data" => %Domain{}})
   end
-
-  @spec domain(Client.t, String.t | integer, String.t | integer, Keyword.t) :: Response.t
-  defdelegate domain(client, account_id, domain_id, options \\ []), to: __MODULE__, as: :get_domain
 
 
   @doc """
@@ -177,9 +171,6 @@ defmodule Dnsimple.Domains do
     |> Response.parse(%{"data" => [%EmailForward{}], "pagination" => %Response.Pagination{}})
   end
 
-  @spec email_forwards(Client.t, String.t | integer, String.t | integer, Keyword.t) :: Response.t
-  defdelegate email_forwards(client, account_id, domain_id, options \\ []), to: __MODULE__, as: :list_email_forwards
-
 
   @doc """
   Creates an email forward for a domain.
@@ -225,9 +216,6 @@ defmodule Dnsimple.Domains do
     |> Response.parse(%{"data" => %EmailForward{}})
   end
 
-  @spec email_forward(Client.t, String.t | integer, String.t | integer, integer, Keyword.t) :: Response.t
-  defdelegate email_forward(client, account_id, domain_id, email_forward_id, options \\ []), to: __MODULE__, as: :get_email_forward
-
 
   @doc """
   Deletes an email forward of a domain.
@@ -269,9 +257,6 @@ defmodule Dnsimple.Domains do
     Listing.get(client, url, options)
     |> Response.parse(%{"data" => [%Push{}]})
   end
-
-  @spec pushes(Client.t, String.t | integer, Keyword.t) :: Response.t
-  defdelegate pushes(client, account_id, options \\ []), to: __MODULE__, as: :list_pushes
 
 
   @doc """
@@ -361,9 +346,6 @@ defmodule Dnsimple.Domains do
     Listing.get(client, url, options)
     |> Response.parse(%{"data" => [%Collaborator{}], "pagination" => %Response.Pagination{}})
   end
-
-  @spec collaborators(Client.t, String.t | integer, String.t | integer, Keyword.t) :: Response.t
-  defdelegate collaborators(client, account_id, domain_id, options \\ []), to: __MODULE__, as: :list_collaborators
 
 
   @doc """

--- a/lib/dnsimple/registrar.ex
+++ b/lib/dnsimple/registrar.ex
@@ -220,9 +220,6 @@ defmodule Dnsimple.Registrar do
     |> Response.parse(%{"data" => %WhoisPrivacy{}})
   end
 
-  @spec whois_privacy(Client.t, integer | String.t, String.t, Keyword.t) :: Response.t
-  defdelegate whois_privacy(client, account_id, domain_name, options \\ []), to: __MODULE__, as: :get_whois_privacy
-
 
   @doc """
   Enables whois privacy for the domain.
@@ -286,8 +283,6 @@ defmodule Dnsimple.Registrar do
     |> Response.parse(%{"data" => []})
   end
 
-  @spec domain_delegation(Client.t, integer | String.t, String.t, Keyword.t) :: Response.t
-  defdelegate domain_delegation(client, account_id, domain_name, options \\ []), to: __MODULE__, as: :get_domain_delegation
 
   @doc """
   Changes the domain's name servers and returns them.

--- a/lib/dnsimple/services.ex
+++ b/lib/dnsimple/services.ex
@@ -32,9 +32,6 @@ defmodule Dnsimple.Services do
     |> Response.parse(%{"data" => [%Service{settings: [%Service.Setting{}]}], "pagination" => %Response.Pagination{}})
   end
 
-  @spec services(Client.t, Keyword.t) :: Response.t
-  defdelegate services(client, options \\ []), to: __MODULE__, as: :list_services
-
 
   @doc """
   Returns a service.
@@ -56,9 +53,6 @@ defmodule Dnsimple.Services do
     Client.get(client, url, options)
     |> Response.parse(%{"data" => %Service{settings: [%Service.Setting{}]}})
   end
-
-  @spec service(Client.t, integer | String.t, Keyword.t) :: Response.t
-  defdelegate service(client, service_id, options \\ []), to: __MODULE__, as: :get_service
 
 
   @doc """

--- a/lib/dnsimple/templates.ex
+++ b/lib/dnsimple/templates.ex
@@ -34,9 +34,6 @@ defmodule Dnsimple.Templates do
     |> Response.parse(%{"data" => [%Template{}], "pagination" => %Response.Pagination{}})
   end
 
-  @spec templates(Client.t, String.t | integer, Keyword.t) :: Response.t
-  defdelegate templates(client, account_id, options \\ []), to: __MODULE__, as: :list_templates
-
 
   @doc """
   Returns a template in the account.
@@ -57,9 +54,6 @@ defmodule Dnsimple.Templates do
     Listing.get(client, url, options)
     |> Response.parse(%{"data" => %Template{}})
   end
-
-  @spec template(Client.t, String.t | integer, String.t | integer, Keyword.t) :: Response.t
-  defdelegate template(client, account_id, template_id, options \\ []), to: __MODULE__, as: :get_template
 
 
   @doc """
@@ -154,9 +148,6 @@ defmodule Dnsimple.Templates do
     |> Response.parse(%{"data" => [%TemplateRecord{}], "pagination" => %Response.Pagination{}})
   end
 
-  @spec template_records(Client.t, String.t | integer, String.t | integer, Keyword.t) :: Response.t
-  defdelegate template_records(client, account_id, template_id, options \\ []), to: __MODULE__, as: :list_template_records
-
 
   @doc """
   Returns a record in of the template.
@@ -177,9 +168,6 @@ defmodule Dnsimple.Templates do
     Listing.get(client, url, options)
     |> Response.parse(%{"data" => %TemplateRecord{}})
   end
-
-  @spec template_record(Client.t, String.t | integer, String.t | integer, integer, Keyword.t) :: Response.t
-  defdelegate template_record(client, account_id, template_id, record_id, options \\ []), to: __MODULE__, as: :get_template_record
 
 
   @doc """

--- a/lib/dnsimple/tlds.ex
+++ b/lib/dnsimple/tlds.ex
@@ -33,9 +33,6 @@ defmodule Dnsimple.Tlds do
     |> Response.parse(%{"data" => [%Tld{}], "pagination" => %Response.Pagination{}})
   end
 
-  @spec tlds(Client.t, Keyword.t) :: Response.t
-  defdelegate tlds(client, options \\ []), to: __MODULE__, as: :list_tlds
-
 
   @doc """
   Returns the information about a TLD.
@@ -57,9 +54,6 @@ defmodule Dnsimple.Tlds do
     |> Response.parse(%{"data" => %Tld{}})
   end
 
-  @spec tld(Client.t, String.t, Keyword.t) :: Response.t
-  defdelegate tld(client, tld, options \\ []), to: __MODULE__, as: :get_tld
-
 
   @doc """
   Returns the extended attributes required for a particular TLD.
@@ -80,8 +74,5 @@ defmodule Dnsimple.Tlds do
     Client.get(client, url, options)
     |> Response.parse(%{"data" => [%TldExtendedAttribute{options: [%TldExtendedAttribute.Option{}]}]})
   end
-
-  @spec tld_extended_attributes(Client.t, String.t,  Keyword.t) :: Response.t
-  defdelegate tld_extended_attributes(client, tld, options \\ []), to: __MODULE__, as: :get_tld_extended_attributes
 
 end

--- a/lib/dnsimple/webhooks.ex
+++ b/lib/dnsimple/webhooks.ex
@@ -24,9 +24,6 @@ defmodule Dnsimple.Webhooks do
     |> Response.parse(%{"data" => [%Webhook{}], "pagination" => %Response.Pagination{}})
   end
 
-  @spec webhooks(Client.t, String.t | integer) :: Response.t
-  defdelegate webhooks(client, account_id, options \\ []), to: __MODULE__, as: :list_webhooks
-
 
   @doc """
   Get a webhook.
@@ -40,9 +37,6 @@ defmodule Dnsimple.Webhooks do
     Client.get(client, url, options)
     |> Response.parse(%{"data" => %Webhook{}})
   end
-
-  @spec webhook(Client.t, String.t | integer, String.t | integer, Keyword.t) :: Response.t
-  defdelegate webhook(client, account_id, webhook_id, options \\ []), to: __MODULE__, as: :get_webhook
 
 
   @doc """

--- a/lib/dnsimple/zones.ex
+++ b/lib/dnsimple/zones.ex
@@ -36,9 +36,6 @@ defmodule Dnsimple.Zones do
     |> Response.parse(%{"data" => [%Zone{}], "pagination" => %Response.Pagination{}})
   end
 
-  @spec zones(Client.t, String.t | integer, Keyword.t) :: Response.t
-  defdelegate zones(client, account_id, options \\ []), to: __MODULE__, as: :list_zones
-
 
   @doc """
   Returns a zone in the account.
@@ -61,9 +58,6 @@ defmodule Dnsimple.Zones do
     |> Response.parse(%{"data" => %Zone{}})
   end
 
-  @spec zone(Client.t, String.t | integer, String.t | integer, Keyword.t) :: Response.t
-  defdelegate zone(client, account_id, zone_id, options \\ []), to: __MODULE__, as: :get_zone
-
 
   @doc """
   Returns the zone file of the zone.
@@ -85,9 +79,6 @@ defmodule Dnsimple.Zones do
     Client.get(client, url, options)
     |> Response.parse(%{"data" => %Zone.File{}})
   end
-
-  @spec zone_file(Client.t, String.t | integer, String.t | integer, Keyword.t) :: Response.t
-  defdelegate zone_file(client, account_id, zone_id, options \\ []), to: __MODULE__, as: :get_zone_file
 
 
   @doc """
@@ -113,9 +104,6 @@ defmodule Dnsimple.Zones do
     |> Response.parse(%{"data" => [%ZoneRecord{}], "pagination" => %Response.Pagination{}})
   end
 
-  @spec zone_records(Client.t, String.t | integer, String.t | integer, Keyword.t) :: Response.t
-  defdelegate zone_records(client, account_id, zone_id, options \\ []), to: __MODULE__, as: :list_zone_records
-
 
   @doc """
   Returns a record of the zone.
@@ -137,9 +125,6 @@ defmodule Dnsimple.Zones do
     Client.get(client, url, options)
     |> Response.parse(%{"data" => %ZoneRecord{}})
   end
-
-  @spec zone_record(Client.t, String.t | integer, String.t | integer, integer, Keyword.t) :: Response.t
-  defdelegate zone_record(client, account_id, zone_id, record_id, options \\ []), to: __MODULE__, as: :get_zone_record
 
 
   @doc """

--- a/test/dnsimple/accounts_test.exs
+++ b/test/dnsimple/accounts_test.exs
@@ -6,7 +6,7 @@ defmodule Dnsimple.AccountsTest do
   @client %Dnsimple.Client{access_token: "i-am-a-token", base_url: "https://api.dnsimple.test"}
 
 
-  describe ".accounts" do
+  describe ".list_accounts" do
     setup do
       {:ok, method: "get", url: "#{@client.base_url}/v2/accounts"}
     end
@@ -47,15 +47,6 @@ defmodule Dnsimple.AccountsTest do
         assert Enum.all?(data, fn(element) -> is_integer(element.id) end)
         assert Enum.all?(data, fn(element) -> is_binary(element.email) end)
         assert Enum.all?(data, fn(element) -> is_binary(element.plan_identifier) end)
-      end
-    end
-
-    test "can be called using the alias .accounts", %{method: method, url: url} do
-      fixture = "listAccounts/success-account.http"
-
-      use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url) do
-        {:ok, response} = @module.accounts(@client)
-        assert response.__struct__ == Dnsimple.Response
       end
     end
   end

--- a/test/dnsimple/certificates_test.exs
+++ b/test/dnsimple/certificates_test.exs
@@ -46,23 +46,15 @@ defmodule Dnsimple.CertificatesTest do
         @module.list_certificates(@client, "1010", "example.com", filter: [common_name_like: "www"])
       end
     end
-
-    test "can be called using the alias .certificates", %{fixture: fixture, method: method, url: url} do
-      use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url) do
-        {:ok, response} = @module.certificates(@client, "1010", "example.com")
-        assert response.__struct__ == Dnsimple.Response
-      end
-    end
   end
 
 
   describe ".get_certificate" do
-    setup do
-      url = "#{@client.base_url}/v2/#{@account_id}/domains/#{@domain_id}/certificates/1"
-      {:ok, fixture: "getCertificate/success.http", method: "get", url: url}
-    end
+    test "returns the certificate in a Dnsimple.Response" do
+      url     = "#{@client.base_url}/v2/#{@account_id}/domains/#{@domain_id}/certificates/1"
+      fixture = "getCertificate/success.http"
+      method  = "get"
 
-    test "returns the certificate in a Dnsimple.Response", %{fixture: fixture, method: method, url: url} do
       use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url) do
         {:ok, response} = @module.get_certificate(@client, @account_id, @domain_id, _certificate_id = 1)
         assert response.__struct__ == Dnsimple.Response
@@ -71,13 +63,6 @@ defmodule Dnsimple.CertificatesTest do
         assert data.__struct__ == Dnsimple.Certificate
         assert data.id == 1
         assert data.name == "www"
-      end
-    end
-
-    test "can be called using the alias .certificate", %{fixture: fixture, method: method, url: url} do
-      use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url) do
-        {:ok, response} = @module.certificate(@client, @account_id, @domain_id, _certificate_id = 1)
-        assert response.__struct__ == Dnsimple.Response
       end
     end
   end
@@ -100,12 +85,11 @@ defmodule Dnsimple.CertificatesTest do
 
 
   describe ".get_certificate_private_key" do
-    setup do
-      url = "#{@client.base_url}/v2/#{@account_id}/domains/#{@domain_id}/certificates/22289/private_key"
-      {:ok, fixture: "getCertificatePrivateKey/success.http", method: "get", url: url}
-    end
+    test "returns the private key in a Dnsimple.Response" do
+      url     = "#{@client.base_url}/v2/#{@account_id}/domains/#{@domain_id}/certificates/22289/private_key"
+      fixture = "getCertificatePrivateKey/success.http"
+      method  = "get"
 
-    test "returns the private key in a Dnsimple.Response", %{fixture: fixture, method: method, url: url} do
       use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url) do
         {:ok, response} = @module.get_certificate_private_key(@client, @account_id, @domain_id, _certificate_id = "22289")
         assert response.__struct__ == Dnsimple.Response
@@ -113,13 +97,6 @@ defmodule Dnsimple.CertificatesTest do
         data = response.data
         assert data.__struct__ == Dnsimple.Certificate
         assert data.private_key == "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEAtzCcMfWoQRt5AMEY0HUb2GaraL1GsWOo6YXdPfe+YDvtnmDw\n23NcoTX7VSeCgU9M3RKs19AsCJcRNTLJ2dmDrAuyCTud9YTAaXQcTOLUhtO8T8+9\nAFVIva2OmAlKCR5saBW3JaRxW7V2aHEd/d1ss1CvNOO7jNppc9NwGSnDHcn3rqNv\n/U3MaU0gpJJRqsKkvcLU6IHJGgxyQ6AbpwJDIqBnzkjHu2IuhGEbRuMjyWLA2qts\njyVlfPotDxUdVouUQpz7dGHUFrLR7ma8QAYuOfl1ZMyrc901HGMa7zwbnFWurs3f\ned7vAosTRZIjnn72/3Wo7L9RiMB+vwr3NX7c9QIDAQABAoIBAEQx32OlzK34GTKT\nr7Yicmw7xEGofIGa1Q2h3Lut13whsxKLif5X0rrcyqRnoeibacS+qXXrJolIG4rP\nTl8/3wmUDQHs5J+6fJqFM+fXZUCP4AFiFzzhgsPBsVyd0KbWYYrZ0qU7s0ttoRe+\nTGjuHgIe3ip1QKNtx2Xr50YmytDydknmro79J5Gfrub1l2iA8SDm1eBrQ4SFaNQ2\nU709pHeSwX8pTihUX2Zy0ifpr0O1wYQjGLneMoG4rrNQJG/z6iUdhYczwwt1kDRQ\n4WkM2sovFOyxbBfoCQ3Gy/eem7OXfjNKUe47DAVLnPkKbqL/3Lo9FD7kcB8K87Ap\nr/vYrl0CgYEA413RAk7571w5dM+VftrdbFZ+Yi1OPhUshlPSehavro8kMGDEG5Ts\n74wEz2X3cfMxauMpMrBk/XnUCZ20AnWQClK73RB5fzPw5XNv473Tt/AFmt7eLOzl\nOcYrhpEHegtsD/ZaljlGtPqsjQAL9Ijhao03m1cGB1+uxI7FgacdckcCgYEAzkKP\n6xu9+WqOol73cnlYPS3sSZssyUF+eqWSzq2YJGRmfr1fbdtHqAS1ZbyC5fZVNZYV\nml1vfXi2LDcU0qS04JazurVyQr2rJZMTlCWVET1vhik7Y87wgCkLwKpbwamPDmlI\n9GY+fLNEa4yfAOOpvpTJpenUScxyKWH2cdYFOOMCgYBhrJnvffINC/d64Pp+BpP8\nyKN+lav5K6t3AWd4H2rVeJS5W7ijiLTIq8QdPNayUyE1o+S8695WrhGTF/aO3+ZD\nKQufikZHiQ7B43d7xL7BVBF0WK3lateGnEVyh7dIjMOdj92Wj4B6mv2pjQ2VvX/p\nAEWVLCtg24/+zL64VgxmXQKBgGosyXj1Zu2ldJcQ28AJxup3YVLilkNje4AXC2No\n6RCSvlAvm5gpcNGE2vvr9lX6YBKdl7FGt8WXBe/sysNEFfgmm45ZKOBCUn+dHk78\nqaeeQHKHdxMBy7utZWdgSqt+ZS299NgaacA3Z9kVIiSLDS4V2VeW7riujXXP/9TJ\nnxaRAoGBAMWXOfNVzfTyrKff6gvDWH+hqNICLyzvkEn2utNY9Q6WwqGuY9fvP/4Z\nXzc48AOBzUr8OeA4sHKJ79sJirOiWHNfD1swtvyVzsFZb6moiNwD3Ce/FzYCa3lQ\nU8blTH/uqpR2pSC6whzJ/lnSdqHUqhyp00000000000000000000\n-----END RSA PRIVATE KEY-----\n"
-      end
-    end
-
-    test "can be called using the alias .certificate_private_key", %{fixture: fixture, method: method, url: url} do
-      use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url) do
-        {:ok, response} = @module.certificate_private_key(@client, @account_id, @domain_id, _certificate_id = "22289")
-        assert response.__struct__ == Dnsimple.Response
       end
     end
   end

--- a/test/dnsimple/contacts_test.exs
+++ b/test/dnsimple/contacts_test.exs
@@ -39,22 +39,14 @@ defmodule Dnsimple.ContactsTest do
         assert response.__struct__ == Dnsimple.Response
       end
     end
-
-    test "can be called using the alias .contacts", %{fixture: fixture, method: method, url: url} do
-      use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url)  do
-        {:ok, response} = @module.contacts(@client, "1010")
-        assert response.__struct__ == Dnsimple.Response
-      end
-    end
   end
 
   describe ".contact" do
-    setup do
-      url = "#{@client.base_url}/v2/1010/contacts/1"
-      {:ok, fixture: "getContact/success.http", method: "get", url: url}
-    end
+    test "returns the contact in a Dnsimple.Response" do
+      url     = "#{@client.base_url}/v2/1010/contacts/1"
+      fixture = "getContact/success.http"
+      method  = "get"
 
-    test "returns the contact in a Dnsimple.Response", %{fixture: fixture, method: method, url: url} do
       use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url)  do
         {:ok, response} = @module.get_contact(@client, 1010, 1)
         assert response.__struct__ == Dnsimple.Response
@@ -79,13 +71,6 @@ defmodule Dnsimple.ContactsTest do
         assert contact.country == "IT"
         assert contact.created_at == "2016-01-19T20:50:26Z"
         assert contact.updated_at == "2016-01-19T20:50:26Z"
-      end
-    end
-
-    test "can be called using the alias .contact", %{fixture: fixture, method: method, url: url} do
-      use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url)  do
-        {:ok, response} = @module.contact(@client, 1010, 1)
-        assert response.__struct__ == Dnsimple.Response
       end
     end
   end

--- a/test/dnsimple/domains_test.exs
+++ b/test/dnsimple/domains_test.exs
@@ -14,7 +14,7 @@ defmodule Dnsimple.DomainsTest do
   describe ".list_domains" do
     setup do
       url = "#{@client.base_url}/v2/#{@account_id}/domains"
-      {:ok, fixture: "listDomains/success.http", method: "get", url: url}
+      {:ok, url: url, fixture: "listDomains/success.http", method: "get"}
     end
 
     test "returns the domains in a Dnsimple.Response", %{fixture: fixture, method: method, url: url} do
@@ -53,13 +53,6 @@ defmodule Dnsimple.DomainsTest do
         assert response.__struct__ == Dnsimple.Response
       end
     end
-
-    test "can be called using the alias .domains", %{fixture: fixture, method: method, url: url} do
-      use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url) do
-        {:ok, response} = @module.domains(@client, @account_id)
-        assert response.__struct__ == Dnsimple.Response
-      end
-    end
   end
 
 
@@ -74,27 +67,19 @@ defmodule Dnsimple.DomainsTest do
 
 
   describe ".get_domain" do
-    setup do
-      url = "#{@client.base_url}/v2/#{@account_id}/domains/example-alpha.com"
-      {:ok, fixture: "getDomain/success.http", method: "get", url: url}
-    end
+    test "builds the correct request" do
+      url     = "#{@client.base_url}/v2/#{@account_id}/domains/example-alpha.com"
+      method  = "get"
+      fixture = "getDomain/success.http"
 
-    test "builds the correct request", %{fixture: fixture, method: method, url: url} do
       use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url) do
-        {:ok, response} = @module.domain(@client, @account_id, _domain_id = "example-alpha.com")
+        {:ok, response} = @module.get_domain(@client, @account_id, _domain_id = "example-alpha.com")
         assert response.__struct__ == Dnsimple.Response
 
         data = response.data
         assert data.__struct__ == Dnsimple.Domain
         assert data.id == 1
         assert data.name == "example-alpha.com"
-      end
-    end
-
-    test "can be called using the alias .domain", %{fixture: fixture, method: method, url: url} do
-      use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url) do
-        {:ok, response} = @module.get_domain(@client, @account_id, "example-alpha.com")
-        assert response.__struct__ == Dnsimple.Response
       end
     end
   end
@@ -185,13 +170,6 @@ defmodule Dnsimple.DomainsTest do
         assert response.__struct__ == Dnsimple.Response
       end
     end
-
-    test "can be called using the alias .email_forwards", %{fixture: fixture, method: method, url: url} do
-      use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url) do
-        {:ok, response} = @module.email_forwards(@client, @account_id, @domain_id)
-        assert response.__struct__ == Dnsimple.Response
-      end
-    end
   end
 
 
@@ -215,12 +193,11 @@ defmodule Dnsimple.DomainsTest do
 
 
   describe ".get_email_forward" do
-    setup do
-      url = "#{@client.base_url}/v2/#{@account_id}/domains/#{@domain_id}/email_forwards/17706"
-      {:ok, fixture: "getEmailForward/success.http", method: "get", url: url}
-    end
+    test "returns the email forward in a Dnsimple.Response" do
+      url     = "#{@client.base_url}/v2/#{@account_id}/domains/#{@domain_id}/email_forwards/17706"
+      method  = "get"
+      fixture = "getEmailForward/success.http"
 
-    test "returns the email forward in a Dnsimple.Response", %{fixture: fixture, method: method, url: url} do
       use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url) do
         {:ok, response} = @module.get_email_forward(@client, @account_id, @domain_id, _email_forward_id = 17706)
         assert response.__struct__ == Dnsimple.Response
@@ -233,13 +210,6 @@ defmodule Dnsimple.DomainsTest do
         assert data.to == "jim@another.com"
         assert data.created_at == "2016-02-04T14:26:50Z"
         assert data.updated_at == "2016-02-04T14:26:50Z"
-      end
-    end
-
-    test "can be called using the alias .email_forward", %{fixture: fixture, method: method, url: url} do
-      use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url) do
-        {:ok, response} = @module.email_forward(@client, @account_id, @domain_id, _email_forward_id = 17706)
-        assert response.__struct__ == Dnsimple.Response
       end
     end
   end
@@ -261,12 +231,11 @@ defmodule Dnsimple.DomainsTest do
 
 
   describe ".list_pushes" do
-    setup do
-      url = "#{@client.base_url}/v2/#{@account_id}/pushes"
-      {:ok, fixture: "listPushes/success.http", method: "get", url: url}
-    end
+    test "returns the account's pushes in a Dnsimple.Response" do
+      url     = "#{@client.base_url}/v2/#{@account_id}/pushes"
+      method  = "get"
+      fixture = "listPushes/success.http"
 
-    test "returns the account's pushes in a Dnsimple.Response", %{fixture: fixture, method: method, url: url} do
       use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url) do
         {:ok, response} = @module.list_pushes(@client, @account_id)
         assert response.__struct__ == Dnsimple.Response
@@ -275,13 +244,6 @@ defmodule Dnsimple.DomainsTest do
         assert is_list(data)
         assert length(data) == 2
         assert Enum.all?(data, fn(single) -> single.__struct__ == Dnsimple.Push end)
-      end
-    end
-
-    test "can be called using the alias .pushes", %{fixture: fixture, method: method, url: url} do
-      use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url) do
-        {:ok, response} = @module.pushes(@client, @account_id)
-        assert response.__struct__ == Dnsimple.Response
       end
     end
   end
@@ -369,13 +331,6 @@ defmodule Dnsimple.DomainsTest do
     test "sends custom headers", %{fixture: fixture, method: method, url: url} do
       use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url) do
         {:ok, response} = @module.list_collaborators(@client, @account_id, @domain_id, headers: %{"X-Header" => "X-Value"})
-        assert response.__struct__ == Dnsimple.Response
-      end
-    end
-
-    test "can be called using the alias .collaborators", %{fixture: fixture, method: method, url: url} do
-      use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url) do
-        {:ok, response} = @module.collaborators(@client, @account_id, @domain_id)
         assert response.__struct__ == Dnsimple.Response
       end
     end

--- a/test/dnsimple/registrar_test.exs
+++ b/test/dnsimple/registrar_test.exs
@@ -188,12 +188,11 @@ defmodule Dnsimple.RegistrarTest do
 
 
   describe ".get_whois_privacy" do
-    setup do
-      url = "#{@client.base_url}/v2/#{@account_id}/registrar/domains/example.com/whois_privacy"
-      {:ok, fixture: "getWhoisPrivacy/success.http", method: "get", url: url}
-    end
+    test "returns the whois privacy in a Dnsimple.Response" do
+      url     = "#{@client.base_url}/v2/#{@account_id}/registrar/domains/example.com/whois_privacy"
+      method  = "get"
+      fixture = "getWhoisPrivacy/success.http"
 
-    test "returns the whois privacy in a Dnsimple.Response", %{fixture: fixture, method: method, url: url} do
       use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url) do
         {:ok, response} = @module.get_whois_privacy(@client, @account_id, "example.com")
         assert response.__struct__ == Dnsimple.Response
@@ -206,13 +205,6 @@ defmodule Dnsimple.RegistrarTest do
         assert data.expires_on == "2017-02-13"
         assert data.created_at == "2016-02-13T14:34:50Z"
         assert data.updated_at == "2016-02-13T14:34:52Z"
-      end
-    end
-
-    test "can be called using the alias .whois_privacy", %{fixture: fixture, method: method, url: url} do
-      use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url) do
-        {:ok, response} = @module.whois_privacy(@client, @account_id, "example.com")
-        assert response.__struct__ == Dnsimple.Response
       end
     end
   end
@@ -265,12 +257,11 @@ defmodule Dnsimple.RegistrarTest do
 
 
   describe ".get_domain_delegation" do
-    setup do
-      url = "#{@client.base_url}/v2/#{@account_id}/registrar/domains/#{@domain_id}/delegation"
-      {:ok, fixture: "getDomainDelegation/success.http", method: "get", url: url}
-    end
+    test "returns the name servers in a Dnsimple.Response" do
+      url     = "#{@client.base_url}/v2/#{@account_id}/registrar/domains/#{@domain_id}/delegation"
+      method  = "get"
+      fixture = "getDomainDelegation/success.http"
 
-    test "returns the name servers in a Dnsimple.Response", %{fixture: fixture, method: method, url: url} do
       use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url)  do
         {:ok, response} = @module.get_domain_delegation(@client, @account_id, @domain_id)
         assert response.__struct__ == Dnsimple.Response
@@ -278,13 +269,6 @@ defmodule Dnsimple.RegistrarTest do
         data = response.data
         assert is_list(data)
         assert data == ~w(ns1.dnsimple.com ns2.dnsimple.com ns3.dnsimple.com ns4.dnsimple.com)
-      end
-    end
-
-    test "it can be called using the alias .domain_delegation", %{fixture: fixture, method: method, url: url} do
-      use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url)  do
-        {:ok, response} = @module.domain_delegation(@client, @account_id, @domain_id)
-        assert response.__struct__ == Dnsimple.Response
       end
     end
   end

--- a/test/dnsimple/services_test.exs
+++ b/test/dnsimple/services_test.exs
@@ -49,23 +49,15 @@ defmodule Dnsimple.ServicesTest do
         assert response.__struct__ == Dnsimple.Response
       end
     end
-
-    test "can be called using the alias .services", %{fixture: fixture, method: method, url: url} do
-      use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url) do
-        {:ok, response} = @module.services(@client)
-        assert response.__struct__ == Dnsimple.Response
-      end
-    end
   end
 
 
   describe ".get_service" do
-    setup do
-      url = "#{@client.base_url}/v2/services/1"
-      {:ok, fixture: "getService/success.http", method: "get", url: url}
-    end
+    test "returns the service in a Dnsimple.Response" do
+      url     = "#{@client.base_url}/v2/services/1"
+      method  = "get"
+      fixture = "getService/success.http"
 
-    test "returns the service in a Dnsimple.Response", %{fixture: fixture, method: method, url: url} do
       use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url)  do
         {:ok, response} = @module.get_service(@client, _service_id = 1)
         assert response.__struct__ == Dnsimple.Response
@@ -82,15 +74,6 @@ defmodule Dnsimple.ServicesTest do
         assert data.settings == [%Dnsimple.Service.Setting{append: ".service1.com", description: "Your Service 1 username is used to connect services to your account.", example: "username", label: "Service 1 Account Username", name: "username", password: false}]
         assert data.created_at == "2014-02-14T19:15:19Z"
         assert data.updated_at == "2016-03-04T09:23:27Z"
-      end
-    end
-
-    test "it can be called using the alias .service", %{fixture: fixture, method: method} do
-      url = "#{@client.base_url}/v2/services/wordpress"
-
-      use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url)  do
-        {:ok, response} = @module.service(@client, _service_id = "wordpress")
-        assert response.__struct__ == Dnsimple.Response
       end
     end
   end

--- a/test/dnsimple/templates_test.exs
+++ b/test/dnsimple/templates_test.exs
@@ -38,23 +38,15 @@ defmodule Dnsimple.TemplatesTest do
         assert response.__struct__ == Dnsimple.Response
       end
     end
-
-    test "it can be called using the alias .templates", %{fixture: fixture, method: method, url: url} do
-      use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url)  do
-        {:ok, response} = @module.templates(@client, @account_id)
-        assert response.__struct__ == Dnsimple.Response
-      end
-    end
   end
 
 
   describe ".get_template" do
-    setup do
-      url = "#{@client.base_url}/v2/#{@account_id}/templates/1"
-      {:ok, fixture: "getTemplate/success.http", method: "get", url: url}
-    end
+    test "returns the template in a Dnsimple.Response" do
+      url     = "#{@client.base_url}/v2/#{@account_id}/templates/1"
+      method  = "get"
+      fixture = "getTemplate/success.http"
 
-    test "returns the template in a Dnsimple.Response", %{fixture: fixture, method: method, url: url} do
       use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url)  do
         {:ok, response} = @module.get_template(@client, @account_id, _template_id = 1)
         assert response.__struct__ == Dnsimple.Response
@@ -68,15 +60,6 @@ defmodule Dnsimple.TemplatesTest do
         assert data.description == "An alpha template."
         assert data.created_at == "2016-03-22T11:08:58Z"
         assert data.updated_at == "2016-03-22T11:08:58Z"
-      end
-    end
-
-    test "it can be called using the alias .template", %{fixture: fixture, method: method} do
-      url = "#{@client.base_url}/v2/#{@account_id}/templates/alpha"
-
-      use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url)  do
-        {:ok, response} = @module.template(@client, @account_id, _template_id = "alpha")
-        assert response.__struct__ == Dnsimple.Response
       end
     end
   end
@@ -170,23 +153,15 @@ defmodule Dnsimple.TemplatesTest do
         assert response.__struct__ == Dnsimple.Response
       end
     end
-
-    test "it can be called using the alias .template_records", %{fixture: fixture, method: method, url: url} do
-      use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url)  do
-        {:ok, response} = @module.template_records(@client, @account_id, _template_id = 1)
-        assert response.__struct__ == Dnsimple.Response
-      end
-    end
   end
 
 
   describe ".get_template_record" do
-    setup do
-      url = "#{@client.base_url}/v2/#{@account_id}/templates/268/records/301"
-      {:ok, fixture: "getTemplateRecord/success.http", method: "get", url: url}
-    end
+    test "returns the record in a Dnsimple.Response" do
+      url     = "#{@client.base_url}/v2/#{@account_id}/templates/268/records/301"
+      method  = "get"
+      fixture = "getTemplateRecord/success.http"
 
-    test "returns the record in a Dnsimple.Response", %{fixture: fixture, method: method, url: url} do
       use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url)  do
         {:ok, response} = @module.get_template_record(@client, @account_id, template_id = 268, record_id = 301)
         assert response.__struct__ == Dnsimple.Response
@@ -202,13 +177,6 @@ defmodule Dnsimple.TemplatesTest do
         assert data.priority == 10
         assert data.created_at == "2016-05-03T08:03:26Z"
         assert data.updated_at == "2016-05-03T08:03:26Z"
-      end
-    end
-
-    test "it can be called using the alias .template_record", %{fixture: fixture, method: method, url: url} do
-      use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url)  do
-        {:ok, response} = @module.template_record(@client, @account_id, _template_id = 268, _record_id = 301)
-        assert response.__struct__ == Dnsimple.Response
       end
     end
   end

--- a/test/dnsimple/tlds_test.exs
+++ b/test/dnsimple/tlds_test.exs
@@ -38,24 +38,16 @@ defmodule Dnsimple.TldsTest do
         assert response.__struct__ == Dnsimple.Response
       end
     end
-
-    test "can be called using the alias .tlds", %{fixture: fixture_file, method: method, url: url} do
-      use_cassette :stub, ExvcrUtils.response_fixture(fixture_file, method: method, url: url) do
-        {:ok, response} = @module.tlds(@client)
-        assert response.__struct__ == Dnsimple.Response
-      end
-    end
   end
 
 
   describe ".get_tld" do
-    setup do
-      url = "#{@client.base_url}/v2/tlds/com"
-      {:ok, fixture: "getTld/success.http", method: "get", url: url}
-    end
+    test "returns the TLD in a Dnsimple.Response" do
+      url     = "#{@client.base_url}/v2/tlds/com"
+      method  = "get"
+      fixture = "getTld/success.http"
 
-    test "returns the TLD in a Dnsimple.Response", %{fixture: fixture_file, method: method, url: url} do
-      use_cassette :stub, ExvcrUtils.response_fixture(fixture_file, method: method, url: url) do
+      use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url) do
         {:ok, response} = @module.get_tld(@client, "com")
         assert response.__struct__ == Dnsimple.Response
 
@@ -72,23 +64,15 @@ defmodule Dnsimple.TldsTest do
         assert data.transfer_enabled == true
       end
     end
-
-    test "can be called using the alias .tld", %{fixture: fixture_file, method: method, url: url} do
-      use_cassette :stub, ExvcrUtils.response_fixture(fixture_file, method: method, url: url) do
-        {:ok, response} = @module.tld(@client, "com")
-        assert response.__struct__ == Dnsimple.Response
-      end
-    end
   end
 
 
   describe ".get_tld_extended_attributes" do
-    setup do
-      url = "#{@client.base_url}/v2/tlds/com/extended_attributes"
-      {:ok, fixture: "getTldExtendedAttributes/success.http", method: "get", url: url}
-    end
+    test "returns the extended attributes in a Dnsimple.Response" do
+      url     = "#{@client.base_url}/v2/tlds/com/extended_attributes"
+      method  = "get"
+      fixture = "getTldExtendedAttributes/success.http"
 
-    test "returns the extended attributes in a Dnsimple.Response", %{fixture: fixture, method: method, url: url} do
       use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url)  do
         {:ok, response} = @module.get_tld_extended_attributes(@client, "com")
         assert response.__struct__ == Dnsimple.Response
@@ -108,13 +92,6 @@ defmodule Dnsimple.TldsTest do
         assert option.title == "UK Individual"
         assert option.value == "IND"
         assert option.description == "UK Individual (our default value)"
-      end
-    end
-
-    test "can be called using the alias .tld_extended_attributes", %{fixture: fixture_file, method: method, url: url} do
-      use_cassette :stub, ExvcrUtils.response_fixture(fixture_file, method: method, url: url) do
-        {:ok, response} = @module.tld_extended_attributes(@client, "com")
-        assert response.__struct__ == Dnsimple.Response
       end
     end
   end

--- a/test/dnsimple/webhooks_test.exs
+++ b/test/dnsimple/webhooks_test.exs
@@ -30,24 +30,16 @@ defmodule Dnsimple.WebhooksTest do
         assert response.__struct__ == Dnsimple.Response
       end
     end
-
-    test "can be called using the alias .webhooks", %{fixture: fixture, method: method, url: url} do
-      use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url) do
-        {:ok, response} = @module.webhooks(@client, @account_id)
-        assert response.__struct__ == Dnsimple.Response
-      end
-    end
   end
 
 
   describe ".get_webhook" do
-    setup do
-      url = "#{@client.base_url}/v2/#{@account_id}/webhooks/1"
-      {:ok, fixture: ExvcrUtils.response_fixture("getWebhook/success.http", method: "get", url: url)}
-    end
+    test "returns the webhook in a Dnsimple.Response" do
+      url     = "#{@client.base_url}/v2/#{@account_id}/webhooks/1"
+      method  = "get"
+      fixture = "getWebhook/success.http"
 
-    test "returns the webhook in a Dnsimple.Response", %{fixture: fixture} do
-      use_cassette :stub, fixture do
+      use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url) do
         {:ok, response} = @module.get_webhook(@client, @account_id, _webhook_id = 1)
         assert response.__struct__ == Dnsimple.Response
 
@@ -55,13 +47,6 @@ defmodule Dnsimple.WebhooksTest do
         assert data.__struct__ == Dnsimple.Webhook
         assert data.id == 1
         assert data.url == "https://webhook.test"
-      end
-    end
-
-    test "can be called using the alias .webhook", %{fixture: fixture} do
-      use_cassette :stub, fixture do
-        {:ok, response} = @module.webhook(@client, @account_id, _webhook_id = 1)
-        assert response.__struct__ == Dnsimple.Response
       end
     end
   end

--- a/test/dnsimple/zones_test.exs
+++ b/test/dnsimple/zones_test.exs
@@ -38,23 +38,15 @@ defmodule Dnsimple.ZonesTest do
         assert response.__struct__ == Dnsimple.Response
       end
     end
-
-    test "can be called using the alias .zones", %{fixture: fixture, method: method, url: url} do
-      use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url) do
-        {:ok, response} = @module.zones(@client, @account_id)
-        assert response.__struct__ == Dnsimple.Response
-      end
-    end
   end
 
 
   describe ".get_zone" do
-    setup do
-      url = "#{@client.base_url}/v2/#{@account_id}/zones/example.com"
-      {:ok, fixture: "getZone/success.http", method: "get", url: url}
-    end
+    test "returns the zone in a Dnsimple.Response" do
+      url     = "#{@client.base_url}/v2/#{@account_id}/zones/example.com"
+      method  = "get"
+      fixture = "getZone/success.http"
 
-    test "returns the zone in a Dnsimple.Response", %{fixture: fixture, method: method, url: url} do
       use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url) do
         {:ok, response} = @module.get_zone(@client, @account_id, _zone_id = "example.com")
         assert response.__struct__ == Dnsimple.Response
@@ -69,13 +61,6 @@ defmodule Dnsimple.ZonesTest do
         assert data.updated_at == "2015-04-23T07:40:03Z"
       end
     end
-
-    test "can be called using the alias .zone", %{fixture: fixture, method: method, url: url} do
-      use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url) do
-        {:ok, response} = @module.zone(@client, @account_id, _zone_id = "example.com")
-        assert response.__struct__ == Dnsimple.Response
-      end
-    end
   end
 
 
@@ -83,25 +68,17 @@ defmodule Dnsimple.ZonesTest do
 
 
   describe ".get_zone_file" do
-    setup do
-      url = "#{@client.base_url}/v2/#{@account_id}/zones/#{@zone_id}/file"
-      {:ok, fixture: "getZoneFile/success.http", method: "get", url: url}
-    end
+    test "returns the zone file in a Dnsimple.Response" do
+      url     = "#{@client.base_url}/v2/#{@account_id}/zones/#{@zone_id}/file"
+      method  = "get"
+      fixture = "getZoneFile/success.http"
 
-    test "returns the zone file in a Dnsimple.Response", %{fixture: fixture, method: method, url: url} do
       use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url) do
         {:ok, response} = @module.get_zone_file(@client, @account_id, @zone_id)
         assert response.__struct__ == Dnsimple.Response
 
         data = response.data
         assert data.zone == "$ORIGIN example.com.\n$TTL 1h\nexample.com. 3600 IN SOA ns1.dnsimple.com. admin.dnsimple.com. 1453132552 86400 7200 604800 300\nexample.com. 3600 IN NS ns1.dnsimple.com.\nexample.com. 3600 IN NS ns2.dnsimple.com.\nexample.com. 3600 IN NS ns3.dnsimple.com.\nexample.com. 3600 IN NS ns4.dnsimple.com.\n"
-      end
-    end
-
-    test "can be called using the alias .zone_file", %{fixture: fixture, method: method, url: url} do
-      use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url) do
-        {:ok, response} = @module.zone_file(@client, @account_id, @zone_id)
-        assert response.__struct__ == Dnsimple.Response
       end
     end
   end
@@ -142,23 +119,15 @@ defmodule Dnsimple.ZonesTest do
         assert response.__struct__ == Dnsimple.Response
       end
     end
-
-    test "can be called using the alias .zone_records", %{fixture: fixture, method: method, url: url} do
-      use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url) do
-        {:ok, response} = @module.zone_records(@client, @account_id, @zone_id)
-        assert response.__struct__ == Dnsimple.Response
-      end
-    end
   end
 
 
   describe ".get_zone_record" do
-    setup do
-      url = "#{@client.base_url}/v2/#{@account_id}/zones/#{@zone_id}/records/5"
-      {:ok, fixture: "getZoneRecord/success.http", method: "get", url: url}
-    end
+    test "returns the record in a Dnsimple.Response" do
+      url     = "#{@client.base_url}/v2/#{@account_id}/zones/#{@zone_id}/records/5"
+      method  = "get"
+      fixture = "getZoneRecord/success.http"
 
-    test "returns the record in a Dnsimple.Response", %{fixture: fixture, method: method, url: url} do
       use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url) do
         {:ok, response} = @module.get_zone_record(@client, @account_id, @zone_id, _record_id = 5)
         assert response.__struct__ == Dnsimple.Response
@@ -177,13 +146,6 @@ defmodule Dnsimple.ZonesTest do
         assert data.regions == ["SV1", "IAD"]
         assert data.created_at == "2016-10-05T09:51:35Z"
         assert data.updated_at == "2016-10-05T09:51:35Z"
-      end
-    end
-
-    test "can be called using the alias .zone_record", %{fixture: fixture, method: method, url: url} do
-      use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url) do
-        {:ok, response} = @module.zone_record(@client, @account_id, @zone_id, _record_id = 5)
-        assert response.__struct__ == Dnsimple.Response
       end
     end
   end

--- a/test/dnsimple_test.exs
+++ b/test/dnsimple_test.exs
@@ -27,14 +27,14 @@ defmodule Dnsimple.ClientTest do
 
     test "handles headers defines as a map", %{client: client, fixture: fixture} do
       use_cassette :stub, fixture  do
-        {:ok, response} = Dnsimple.Domains.domains(client, "1010", headers: %{page: 2})
+        {:ok, response} = Dnsimple.Domains.list_domains(client, "1010", headers: %{page: 2})
         assert response.__struct__ == Dnsimple.Response
       end
     end
 
     test "handles headers defines as a list", %{client: client, fixture: fixture} do
       use_cassette :stub, fixture  do
-        {:ok, response} = Dnsimple.Domains.domains(client, "1010", headers: [{"X-Header", "X-Value"}])
+        {:ok, response} = Dnsimple.Domains.list_domains(client, "1010", headers: [{"X-Header", "X-Value"}])
         assert response.__struct__ == Dnsimple.Response
       end
     end


### PR DESCRIPTION
Closes #95 

This PR:

- Removes the defined aliases in the client.
- Removes the tests for the existence of aliases.
- Updates calls to aliases in the codebase.
