### PR TITLE
ignore .iex.exs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /deps
 erl_crash.dump
 *.ez
+.iex.exs


### PR DESCRIPTION
This is super handy to setup a development iex session:

```
👌  dnsimple-elixir git:(elixir-dates) ✗ cat .iex.exs
client = %Dnsimple.Client{access_token: "NOT-MY-TOKEN!"}
account_id = 12345678
👌  dnsimple-elixir git:(elixir-dates) ✗ iex -S mix
Erlang/OTP 19 [erts-8.1] [source] [64-bit] [smp:4:4] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]

Interactive Elixir (1.3.4) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> Dnsimple.Domains.list_domains(client, account_id)
....
```