### PR TITLE
Relax poison dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 #### master
 
+- CHANGED: Relax poison dependency to fix incompatibility with Phoenix (GH-110)
+
+
 #### Release 1.1.0
 
  - NEW: Add support for DNSSEC endpoints (GH-109)

--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,7 @@ defmodule Dnsimple.Mixfile do
   defp deps do
     [
       {:httpoison, "~> 0.11.1"},
-      {:poison, "~> 3.1.0"},
+      {:poison, ">= 2.0.0"},
       {:exvcr, "~> 0.8.2", only: :test},
       {:ex_doc, ">= 0.0.0", only: :dev},
     ]


### PR DESCRIPTION
Fix incompatibility with Phoenix (GH-110)

Tests are passing:

```
==> dnsimple
Compiling 42 files (.ex)
Generated dnsimple app
................................................................................................................................................

Finished in 10.5 seconds
144 tests, 0 failures
```