### PR TITLE
Update registrar endpoint URLs

### DIFF
--- a/lib/dnsimple/registrar.ex
+++ b/lib/dnsimple/registrar.ex
@@ -133,7 +133,7 @@ defmodule Dnsimple.Registrar do
   """
   @spec transfer_domain(Client.t, String.t, String.t, Keyword.t, Keyword.t) :: Response.t
   def transfer_domain(client, account_id, domain_name, attributes \\ [], options \\ []) do
-    url = Client.versioned("/#{account_id}/registrar/domains/#{domain_name}/transfer")
+    url = Client.versioned("/#{account_id}/registrar/domains/#{domain_name}/transfers")
 
     Client.post(client, url, attributes, options)
     |> Response.parse(%{"data" => %DomainTransfer{}})

--- a/lib/dnsimple/registrar.ex
+++ b/lib/dnsimple/registrar.ex
@@ -85,7 +85,7 @@ defmodule Dnsimple.Registrar do
   """
   @spec register_domain(Client.t, String.t, String.t, Keyword.t, Keyword.t) :: Response.t
   def register_domain(client, account_id, domain_name, attributes \\ [], options \\ []) do
-    url = Client.versioned("/#{account_id}/registrar/domains/#{domain_name}/registration")
+    url = Client.versioned("/#{account_id}/registrar/domains/#{domain_name}/registrations")
 
     Client.post(client, url, attributes, options)
     |> Response.parse(%{"data" => %DomainRegistration{}})

--- a/lib/dnsimple/registrar.ex
+++ b/lib/dnsimple/registrar.ex
@@ -107,7 +107,7 @@ defmodule Dnsimple.Registrar do
   """
   @spec renew_domain(Client.t, String.t, String.t, Keyword.t, Keyword.t) :: Response.t
   def renew_domain(client, account_id, domain_name, attributes \\ [], options \\ []) do
-    url = Client.versioned("/#{account_id}/registrar/domains/#{domain_name}/renewal")
+    url = Client.versioned("/#{account_id}/registrar/domains/#{domain_name}/renewals")
 
     Client.post(client, url, attributes, options)
     |> Response.parse(%{"data" => %DomainRenewal{}})

--- a/lib/dnsimple/registrar.ex
+++ b/lib/dnsimple/registrar.ex
@@ -154,7 +154,7 @@ defmodule Dnsimple.Registrar do
   """
   @spec transfer_domain_out(Client.t, String.t, String.t, Keyword.t) :: Response.t
   def transfer_domain_out(client, account_id, domain_name, options \\ []) do
-    url = Client.versioned("/#{account_id}/registrar/domains/#{domain_name}/transfer_out")
+    url = Client.versioned("/#{account_id}/registrar/domains/#{domain_name}/authorize_transfer_out")
 
     Client.post(client, url, Client.empty_body(), options)
     |> Response.parse(nil)

--- a/test/dnsimple/registrar_test.exs
+++ b/test/dnsimple/registrar_test.exs
@@ -144,7 +144,7 @@ defmodule Dnsimple.RegistrarTest do
 
   describe ".transfer_domain_out" do
     test "requests the transfer out and returns an empty Dnsimple.Response" do
-      url         = "#{@client.base_url}/v2/#{@account_id}/registrar/domains/example.com/transfer_out"
+      url         = "#{@client.base_url}/v2/#{@account_id}/registrar/domains/example.com/authorize_transfer_out"
       method      = "post"
       fixture     = "transferDomainOut/success.http"
 

--- a/test/dnsimple/registrar_test.exs
+++ b/test/dnsimple/registrar_test.exs
@@ -90,7 +90,7 @@ defmodule Dnsimple.RegistrarTest do
 
   describe ".renew_domain" do
     test "returns the renewed domain in a Dnsimple.Response" do
-      url         = "#{@client.base_url}/v2/#{@account_id}/registrar/domains/example.com/renewal"
+      url         = "#{@client.base_url}/v2/#{@account_id}/registrar/domains/example.com/renewals"
       method      = "post"
       fixture     = "renewDomain/success.http"
       attributes  = %{period: 3}

--- a/test/dnsimple/registrar_test.exs
+++ b/test/dnsimple/registrar_test.exs
@@ -116,7 +116,7 @@ defmodule Dnsimple.RegistrarTest do
 
   describe ".transfer_domain" do
     test "returns the domain to be transferred in a Dnsimple.Response" do
-      url         = "#{@client.base_url}/v2/#{@account_id}/registrar/domains/example.com/transfer"
+      url         = "#{@client.base_url}/v2/#{@account_id}/registrar/domains/example.com/transfers"
       method      = "post"
       fixture     = "transferDomain/success.http"
       attributes  = %{registrant_id: 10, auth_code: "x1y2z3", auto_renew: false, whois_privacy: false}

--- a/test/dnsimple/registrar_test.exs
+++ b/test/dnsimple/registrar_test.exs
@@ -61,7 +61,7 @@ defmodule Dnsimple.RegistrarTest do
 
   describe ".register_domain" do
     test "returns the registered domain in a Dnsimple.Response" do
-      url         = "#{@client.base_url}/v2/#{@account_id}/registrar/domains/example.com/registration"
+      url         = "#{@client.base_url}/v2/#{@account_id}/registrar/domains/example.com/registrations"
       method      = "post"
       fixture     = "registerDomain/success.http"
       attributes  = %{registrant_id: 2, auto_renew: false, whois_privacy: false}


### PR DESCRIPTION
This PR updates the URLs to the public, [documented](https://developer.dnsimple.com/v2/registrar/) ones.