### PR TITLE
Fix compilation warning

### DIFF
--- a/lib/dnsimple.ex
+++ b/lib/dnsimple.ex
@@ -254,13 +254,13 @@ defmodule Dnsimple do
     end
 
     defp get_pages(_module, _function, _params, all, _page, _pages_left = 0), do: {:ok, all}
-    defp get_pages(module, function, params, all, page, pages_left) do
+    defp get_pages(module, function, params, all, page, _pages_left) do
       case apply(module, function, add_page_param(params, page)) do
         {:ok, response} ->
-          all        = all ++ response.data
-          next_page  = page + 1
-          pages_left = response.pagination.total_pages - page
-          get_pages(module, function, params, all, next_page, pages_left)
+          all       = all ++ response.data
+          next      = page + 1
+          remaining = response.pagination.total_pages - page
+          get_pages(module, function, params, all, next, remaining)
         {:error, response} -> {:error, response}
       end
     end


### PR DESCRIPTION
Closes #124.

This PR:
- Adds underscore to function parameter to mark it as unused.
- Rename local variables to prevent shadowing (it works as expected even without renaming them, but I think this makes the function less confusing).