### PR TITLE
Implement client methods for Transfer API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ## master
 
 - CHANGED: Requires Elixir >= 1.6.
+- NEW: Added `Dnsimple.Registrar.get_domain_transfer` to retrieve a domain transfer. (dnsimple/dnsimple-elixir#133)
+- NEW: Added `Dnsimple.Registrar.cancel_domain_transfer` to cancel an in progress domain transfer. (dnsimple/dnsimple-elixir#133)
+- NEW: Added `status_description` to `Dnsimple.DomainTransfer` struct to identify the failure reason of a transfer. (dnsimple/dnsimple-elixir#133)
 
 
 ## Release 1.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 ## master
 
 - CHANGED: Requires Elixir >= 1.6.
-- NEW: Added `Dnsimple.Registrar.get_domain_transfer` to retrieve a domain transfer. (dnsimple/dnsimple-elixir#133)
-- NEW: Added `Dnsimple.Registrar.cancel_domain_transfer` to cancel an in progress domain transfer. (dnsimple/dnsimple-elixir#133)
+- NEW: Added `Dnsimple.Registrar.get_domain_transfer/5` to retrieve a domain transfer. (dnsimple/dnsimple-elixir#133)
+- NEW: Added `Dnsimple.Registrar.cancel_domain_transfer/5` to cancel an in progress domain transfer. (dnsimple/dnsimple-elixir#133)
 - NEW: Added `status_description` to `Dnsimple.DomainTransfer` struct to identify the failure reason of a transfer. (dnsimple/dnsimple-elixir#133)
 
 

--- a/lib/dnsimple/domain_transfer.ex
+++ b/lib/dnsimple/domain_transfer.ex
@@ -12,12 +12,13 @@ defmodule Dnsimple.DomainTransfer do
     state: String.t,
     auto_renew: boolean,
     whois_privacy: boolean,
+    status_description: String.t,
     created_at: String.t,
     updated_at: String.t,
   }
 
   defstruct ~w(id domain_id registrant_id
-               state auto_renew whois_privacy
+               state auto_renew whois_privacy status_description
                created_at updated_at)a
 
 end

--- a/lib/dnsimple/registrar.ex
+++ b/lib/dnsimple/registrar.ex
@@ -140,6 +140,46 @@ defmodule Dnsimple.Registrar do
     |> Response.parse(%{"data" => %DomainTransfer{}})
   end
 
+  @doc """
+  Retrieves the details of an existing domain transfer.
+
+  See:
+  - https://developer.dnsimple.com/v2/registrar/#getDomainTransfer
+
+  ## Examples:
+
+      client = %Dnsimple.Client{access_token: "a1b2c3d4"}
+      {:ok, response} = Dnsimple.Registrar.get_domain_transfer(client, account_id = 1010, domain_name = "example.com", transfer_id = 42)
+
+  """
+  @spec get_domain_transfer(Client.t, String.t | integer, String.t, String.t | integer, Keyword.t) :: {:ok|:error, Response.t}
+  def get_domain_transfer(client, account_id, domain_name, domain_transfer_id, options \\ []) do
+    url = Client.versioned("/#{account_id}/registrar/domains/#{domain_name}/transfers/#{domain_transfer_id}")
+
+    Client.get(client, url, options)
+    |> Response.parse(%{"data" => %DomainTransfer{}})
+  end
+
+  @doc """
+  Cancels an in progress domain transfer.
+
+  See:
+  - https://developer.dnsimple.com/v2/registrar/#cancelDomainTransfer
+
+  ## Examples:
+
+      client = %Dnsimple.Client{access_token: "a1b2c3d4"}
+      {:ok, response} = Dnsimple.Registrar.cancel_domain_transfer(client, account_id = 1010, domain_name = "example.com", transfer_id = 42)
+
+  """
+  @spec cancel_domain_transfer(Client.t, String.t | integer, String.t, String.t | integer, Keyword.t) :: {:ok|:error, Response.t}
+  def cancel_domain_transfer(client, account_id, domain_name, domain_transfer_id, options \\ []) do
+    url = Client.versioned("/#{account_id}/registrar/domains/#{domain_name}/transfers/#{domain_transfer_id}")
+
+    Client.delete(client, url, options)
+    |> Response.parse(%{"data" => %DomainTransfer{}})
+  end
+
 
   @doc """
   Requests the transfer of a domain out of DNSimple.

--- a/test/dnsimple/registrar_test.exs
+++ b/test/dnsimple/registrar_test.exs
@@ -138,6 +138,55 @@ defmodule Dnsimple.RegistrarTest do
     end
   end
 
+  describe ".get_domain_transfer" do
+    test "returns the domain transfer in a Dnsimple.Response" do
+      url         = "#{@client.base_url}/v2/#{@account_id}/registrar/domains/example.com/transfers/42"
+      method      = "get"
+      fixture     = "getDomainTransfer/success.http"
+
+      use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url) do
+        {:ok, response} = @module.get_domain_transfer(@client, @account_id, "example.com", 42)
+        assert response.__struct__ == Dnsimple.Response
+
+        data = response.data
+        assert data.__struct__ == Dnsimple.DomainTransfer
+        assert data.id == 42
+        assert data.domain_id == 2
+        assert data.registrant_id == 3
+        assert data.state == "cancelled"
+        assert data.auto_renew == false
+        assert data.whois_privacy == false
+        assert data.status_description == "Canceled by customer"
+        assert data.created_at == "2020-04-27T18:08:44Z"
+        assert data.updated_at == "2020-04-27T18:20:01Z"
+      end
+    end
+  end
+
+  describe ".cancel_domain_transfer" do
+    test "returns the domain transfer in a Dnsimple.Response" do
+      url         = "#{@client.base_url}/v2/#{@account_id}/registrar/domains/example.com/transfers/42"
+      method      = "delete"
+      fixture     = "cancelDomainTransfer/success.http"
+
+      use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url) do
+        {:ok, response} = @module.cancel_domain_transfer(@client, @account_id, "example.com", 42)
+        assert response.__struct__ == Dnsimple.Response
+
+        data = response.data
+        assert data.__struct__ == Dnsimple.DomainTransfer
+        assert data.id == 42
+        assert data.domain_id == 6
+        assert data.registrant_id == 1
+        assert data.state == "transferring"
+        assert data.auto_renew == true
+        assert data.whois_privacy == false
+        assert data.status_description == nil
+        assert data.created_at == "2020-04-24T19:19:03Z"
+        assert data.updated_at == "2020-04-24T19:19:15Z"
+      end
+    end
+  end
 
   describe ".transfer_domain_out" do
     test "requests the transfer out and returns an empty Dnsimple.Response" do

--- a/test/dnsimple/registrar_test.exs
+++ b/test/dnsimple/registrar_test.exs
@@ -140,50 +140,50 @@ defmodule Dnsimple.RegistrarTest do
 
   describe ".get_domain_transfer" do
     test "returns the domain transfer in a Dnsimple.Response" do
-      url         = "#{@client.base_url}/v2/#{@account_id}/registrar/domains/example.com/transfers/42"
+      url         = "#{@client.base_url}/v2/#{@account_id}/registrar/domains/example.com/transfers/358"
       method      = "get"
       fixture     = "getDomainTransfer/success.http"
 
       use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url) do
-        {:ok, response} = @module.get_domain_transfer(@client, @account_id, "example.com", 42)
+        {:ok, response} = @module.get_domain_transfer(@client, @account_id, "example.com", 358)
         assert response.__struct__ == Dnsimple.Response
 
         data = response.data
         assert data.__struct__ == Dnsimple.DomainTransfer
-        assert data.id == 42
-        assert data.domain_id == 2
-        assert data.registrant_id == 3
+        assert data.id == 358
+        assert data.domain_id == 180716
+        assert data.registrant_id == 2459
         assert data.state == "cancelled"
         assert data.auto_renew == false
         assert data.whois_privacy == false
         assert data.status_description == "Canceled by customer"
-        assert data.created_at == "2020-04-27T18:08:44Z"
-        assert data.updated_at == "2020-04-27T18:20:01Z"
+        assert data.created_at == "2020-05-18T16:54:15Z"
+        assert data.updated_at == "2020-05-18T17:00:02Z"
       end
     end
   end
 
   describe ".cancel_domain_transfer" do
     test "returns the domain transfer in a Dnsimple.Response" do
-      url         = "#{@client.base_url}/v2/#{@account_id}/registrar/domains/example.com/transfers/42"
+      url         = "#{@client.base_url}/v2/#{@account_id}/registrar/domains/example.com/transfers/358"
       method      = "delete"
       fixture     = "cancelDomainTransfer/success.http"
 
       use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url) do
-        {:ok, response} = @module.cancel_domain_transfer(@client, @account_id, "example.com", 42)
+        {:ok, response} = @module.cancel_domain_transfer(@client, @account_id, "example.com", 358)
         assert response.__struct__ == Dnsimple.Response
 
         data = response.data
         assert data.__struct__ == Dnsimple.DomainTransfer
-        assert data.id == 42
-        assert data.domain_id == 6
-        assert data.registrant_id == 1
+        assert data.id == 358
+        assert data.domain_id == 180716
+        assert data.registrant_id == 2459
         assert data.state == "transferring"
-        assert data.auto_renew == true
+        assert data.auto_renew == false
         assert data.whois_privacy == false
         assert data.status_description == nil
-        assert data.created_at == "2020-04-24T19:19:03Z"
-        assert data.updated_at == "2020-04-24T19:19:15Z"
+        assert data.created_at == "2020-05-18T16:54:15Z"
+        assert data.updated_at == "2020-05-18T16:54:22Z"
       end
     end
   end

--- a/test/fixtures.http/cancelDomainTransfer/success.http
+++ b/test/fixtures.http/cancelDomainTransfer/success.http
@@ -1,0 +1,30 @@
+HTTP/1.1 202 Accepted
+Server: nginx
+Date: Wed, 29 Apr 2020 19:49:41 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+Status: 202 Accepted
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2397
+X-RateLimit-Reset: 1588193270
+ETag: W/"8404bf2739e44e9f69f3a5199466776d"
+Cache-Control: no-store, must-revalidate, private, max-age=0
+X-Request-Id: 10d75bcf-0066-4d38-98a2-dc18dd5b6f4c
+X-Runtime: 1.752154
+Strict-Transport-Security: max-age=31536000
+
+{
+  "data": {
+    "id": 42,
+    "domain_id": 6,
+    "registrant_id": 1,
+    "state": "transferring",
+    "auto_renew": true,
+    "whois_privacy": false,
+    "premium_price": null,
+    "status_description": null,
+    "created_at": "2020-04-24T19:19:03Z",
+    "updated_at": "2020-04-24T19:19:15Z"
+  }
+}

--- a/test/fixtures.http/cancelDomainTransfer/success.http
+++ b/test/fixtures.http/cancelDomainTransfer/success.http
@@ -1,30 +1,19 @@
 HTTP/1.1 202 Accepted
 Server: nginx
-Date: Wed, 29 Apr 2020 19:49:41 GMT
+Date: Mon, 18 May 2020 16:55:35 GMT
 Content-Type: application/json; charset=utf-8
 Transfer-Encoding: chunked
 Connection: keep-alive
-Status: 202 Accepted
 X-RateLimit-Limit: 2400
-X-RateLimit-Remaining: 2397
-X-RateLimit-Reset: 1588193270
-ETag: W/"8404bf2739e44e9f69f3a5199466776d"
-Cache-Control: no-store, must-revalidate, private, max-age=0
-X-Request-Id: 10d75bcf-0066-4d38-98a2-dc18dd5b6f4c
-X-Runtime: 1.752154
-Strict-Transport-Security: max-age=31536000
+X-RateLimit-Remaining: 2398
+X-RateLimit-Reset: 1589824450
+Cache-Control: no-cache
+X-Request-Id: c9ecfbd2-3db4-4550-a6d6-8dd9f5b68a06
+X-Runtime: 0.905412
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
 
-{
-  "data": {
-    "id": 42,
-    "domain_id": 6,
-    "registrant_id": 1,
-    "state": "transferring",
-    "auto_renew": true,
-    "whois_privacy": false,
-    "premium_price": null,
-    "status_description": null,
-    "created_at": "2020-04-24T19:19:03Z",
-    "updated_at": "2020-04-24T19:19:15Z"
-  }
-}
+{"data":{"id":358,"domain_id":180716,"registrant_id":2459,"state":"transferring","auto_renew":false,"whois_privacy":false,"premium_price":null,"status_description":null,"created_at":"2020-05-18T16:54:15Z","updated_at":"2020-05-18T16:54:22Z"}}

--- a/test/fixtures.http/getDomainTransfer/success.http
+++ b/test/fixtures.http/getDomainTransfer/success.http
@@ -1,0 +1,30 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Mon, 27 Apr 2020 19:40:00 GMT
+Content-Type: application/json; charset=utf-8
+Transfer-Encoding: chunked
+Connection: keep-alive
+Status: 200 OK
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2398
+X-RateLimit-Reset: 1588019949
+ETag: W/"8404bf2739e44e9f69f3a5199466776d"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 4818d867-1f72-4619-ab46-d345e6dd25eb
+X-Runtime: 0.092854
+Strict-Transport-Security: max-age=31536000
+
+{
+  "data": {
+    "id": 42,
+    "domain_id": 2,
+    "registrant_id": 3,
+    "state": "cancelled",
+    "auto_renew": false,
+    "whois_privacy": false,
+    "premium_price": null,
+    "status_description": "Canceled by customer",
+    "created_at": "2020-04-27T18:08:44Z",
+    "updated_at": "2020-04-27T18:20:01Z"
+  }
+}

--- a/test/fixtures.http/getDomainTransfer/success.http
+++ b/test/fixtures.http/getDomainTransfer/success.http
@@ -1,30 +1,21 @@
 HTTP/1.1 200 OK
 Server: nginx
-Date: Mon, 27 Apr 2020 19:40:00 GMT
+Date: Mon, 18 May 2020 17:03:54 GMT
 Content-Type: application/json; charset=utf-8
 Transfer-Encoding: chunked
 Connection: keep-alive
-Status: 200 OK
 X-RateLimit-Limit: 2400
-X-RateLimit-Remaining: 2398
-X-RateLimit-Reset: 1588019949
-ETag: W/"8404bf2739e44e9f69f3a5199466776d"
+X-RateLimit-Remaining: 2396
+X-RateLimit-Reset: 1589824450
+ETag: W/"9f81d47057f629dd921ccabff433ccac"
 Cache-Control: max-age=0, private, must-revalidate
-X-Request-Id: 4818d867-1f72-4619-ab46-d345e6dd25eb
-X-Runtime: 0.092854
+X-Request-Id: 7af4e96b-471d-4619-a0b6-b5d0d7261e75
+X-Runtime: 0.060273
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
 Strict-Transport-Security: max-age=31536000
 
-{
-  "data": {
-    "id": 42,
-    "domain_id": 2,
-    "registrant_id": 3,
-    "state": "cancelled",
-    "auto_renew": false,
-    "whois_privacy": false,
-    "premium_price": null,
-    "status_description": "Canceled by customer",
-    "created_at": "2020-04-27T18:08:44Z",
-    "updated_at": "2020-04-27T18:20:01Z"
-  }
-}
+{"data":{"id":358,"domain_id":180716,"registrant_id":2459,"state":"cancelled","auto_renew":false,"whois_privacy":false,"premium_price":null,"status_description":"Canceled by customer","created_at":"2020-05-18T16:54:15Z","updated_at":"2020-05-18T17:00:02Z"}}


### PR DESCRIPTION
This commit introduces two client methods for the new features in
TransferAPI:
- getDomainTransfer - Retrieves the information for a specific domain
transfer
- cancelDomainTransfer - Cancels an in progress domain transfer

It also adds the new status_description field in the DomainTransfer
response to identify the failure reason.