### PR TITLE
Deprecate Domain `expires_on` in favor of `expires_at`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## master
 
-- CHANGED: `Dnsimple.Domain` struct now have `expires_at` (timestamp) instead of `expires_on` (date only).
+- CHANGED: `Dnsimple.Domain` struct now has `expires_at` (timestamp) to be used in favor of `expires_on` (date only).
   (dnsimple/dnsimple-elixir#135)
 
 ## Release 2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## master
+
+- CHANGED: `Dnsimple.Domain` struct now have `expires_at` (timestamp) instead of `expires_on` (date only).
+  (dnsimple/dnsimple-elixir#135)
 
 ## Release 2.0.0
 

--- a/lib/dnsimple/domain.ex
+++ b/lib/dnsimple/domain.ex
@@ -18,11 +18,11 @@ defmodule Dnsimple.Domain do
     auto_renew: boolean,
     private_whois: boolean,
     expires_at: String.t,
+    expires_on: String.t,
     created_at: String.t,
     updated_at: String.t,
   }
 
   defstruct ~w(id account_id registrant_id name unicode_name token state
-               auto_renew private_whois expires_at created_at updated_at)a
-
+               auto_renew private_whois expires_at expires_on created_at updated_at)a
 end

--- a/lib/dnsimple/domain.ex
+++ b/lib/dnsimple/domain.ex
@@ -17,12 +17,12 @@ defmodule Dnsimple.Domain do
     state: String.t,
     auto_renew: boolean,
     private_whois: boolean,
-    expires_on: String.t,
+    expires_at: String.t,
     created_at: String.t,
     updated_at: String.t,
   }
 
   defstruct ~w(id account_id registrant_id name unicode_name token state
-               auto_renew private_whois expires_on created_at updated_at)a
+               auto_renew private_whois expires_at created_at updated_at)a
 
 end

--- a/lib/dnsimple/domain.ex
+++ b/lib/dnsimple/domain.ex
@@ -7,6 +7,7 @@ defmodule Dnsimple.Domain do
   - https://developer.dnsimple.com/v2/domains/#domain-attributes
   """
 
+  @doc "expires_on is deprecated in favor of expires_at"
   @type t :: %__MODULE__{
     id: integer,
     account_id: integer,

--- a/lib/dnsimple/domain_registration.ex
+++ b/lib/dnsimple/domain_registration.ex
@@ -20,6 +20,6 @@ defmodule Dnsimple.DomainRegistration do
 
   defstruct ~w(id domain_id registrant_id
                period state auto_renew whois_privacy
-               expires_on created_at updated_at)a
+               created_at updated_at)a
 
 end

--- a/test/dnsimple/domains_test.exs
+++ b/test/dnsimple/domains_test.exs
@@ -86,6 +86,7 @@ defmodule Dnsimple.DomainsTest do
         assert data.auto_renew == false
         assert data.private_whois == false
         assert data.expires_at == "2021-06-05T02:15:00Z"
+        assert data.expires_on == "2021-06-05"
         assert data.created_at == "2020-06-04T19:15:14Z"
         assert data.updated_at == "2020-06-04T19:15:21Z"
       end

--- a/test/dnsimple/domains_test.exs
+++ b/test/dnsimple/domains_test.exs
@@ -78,9 +78,16 @@ defmodule Dnsimple.DomainsTest do
 
         data = response.data
         assert data.__struct__ == Dnsimple.Domain
-        assert data.id == 1
+        assert data.id == 181984
+        assert data.registrant_id == 2715
         assert data.name == "example-alpha.com"
         assert data.unicode_name == "example-alpha.com"
+        assert data.state == "registered"
+        assert data.auto_renew == false
+        assert data.private_whois == false
+        assert data.expires_at == "2021-06-05T02:15:00Z"
+        assert data.created_at == "2020-06-04T19:15:14Z"
+        assert data.updated_at == "2020-06-04T19:15:21Z"
       end
     end
   end

--- a/test/fixtures.http/createDomain/created.http
+++ b/test/fixtures.http/createDomain/created.http
@@ -1,16 +1,21 @@
 HTTP/1.1 201 Created
 Server: nginx
-Date: Fri, 18 Dec 2015 16:38:07 GMT
+Date: Thu, 04 Jun 2020 19:47:05 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
-X-RateLimit-Limit: 4000
-X-RateLimit-Remaining: 3986
-X-RateLimit-Reset: 1450456686
-ETag: W/"87e018b900e5f210c3236f63d3b2f4df"
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2378
+X-RateLimit-Reset: 1591300248
+ETag: W/"399e70627412fa31dba332feca5e8ec1"
 Cache-Control: max-age=0, private, must-revalidate
-X-Request-Id: 0d6f1ea7-f702-4317-85f0-04874b69315d
-X-Runtime: 0.257489
+X-Request-Id: ee897eee-36cc-4b7f-be15-f4627f344bf9
+X-Runtime: 0.194561
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":1,"account_id":1010,"registrant_id":null,"name":"example-alpha.com","unicode_name":"example-alpha.com","token":"domain-token","state":"hosted","auto_renew":false,"private_whois":false,"expires_on":null,"created_at":"2014-12-06T15:56:55Z","updated_at":"2015-12-09T00:20:56Z"}}
+{"data":{"id":181985,"account_id":1385,"registrant_id":null,"name":"example-beta.com","unicode_name":"example-beta.com","state":"hosted","auto_renew":false,"private_whois":false,"expires_on":null,"expires_at":null,"created_at":"2020-06-04T19:47:05Z","updated_at":"2020-06-04T19:47:05Z"}}

--- a/test/fixtures.http/getDomain/success.http
+++ b/test/fixtures.http/getDomain/success.http
@@ -1,16 +1,21 @@
 HTTP/1.1 200 OK
 Server: nginx
-Date: Wed, 16 Dec 2015 21:54:55 GMT
+Date: Thu, 04 Jun 2020 19:37:22 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
-X-RateLimit-Limit: 4000
-X-RateLimit-Remaining: 3993
-X-RateLimit-Reset: 1450302894
-ETag: W/"e7282090a87379d1fa3507ba6bfd1721"
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2379
+X-RateLimit-Reset: 1591300247
+ETag: W/"ff4a8463ecca39d4869695d66de60043"
 Cache-Control: max-age=0, private, must-revalidate
-X-Request-Id: 3d8da18a-b8b2-4bfd-827c-860da837c80f
-X-Runtime: 0.020346
+X-Request-Id: 2e8259ab-c933-487e-8f85-d23f1cdf62fa
+X-Runtime: 0.019482
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":1,"account_id":1010,"registrant_id":null,"name":"example-alpha.com","unicode_name":"example-alpha.com","token":"domain-token","state":"hosted","auto_renew":false,"private_whois":false,"expires_on":null,"created_at":"2014-12-06T15:56:55Z","updated_at":"2015-12-09T00:20:56Z"}}
+{"data":{"id":181984,"account_id":1385,"registrant_id":2715,"name":"example-alpha.com","unicode_name":"example-alpha.com","state":"registered","auto_renew":false,"private_whois":false,"expires_on":"2021-06-05","expires_at":"2021-06-05T02:15:00Z","created_at":"2020-06-04T19:15:14Z","updated_at":"2020-06-04T19:15:21Z"}}

--- a/test/fixtures.http/listDomains/success.http
+++ b/test/fixtures.http/listDomains/success.http
@@ -1,16 +1,21 @@
 HTTP/1.1 200 OK
 Server: nginx
-Date: Wed, 16 Dec 2015 13:36:11 GMT
+Date: Thu, 04 Jun 2020 19:54:16 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
+Transfer-Encoding: identity
 Connection: keep-alive
-X-RateLimit-Limit: 4000
-X-RateLimit-Remaining: 3997
-X-RateLimit-Reset: 1450272970
-ETag: W/"2679531e6cce6cd326f255255d7a0005"
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2399
+X-RateLimit-Reset: 1591304056
+ETag: W/"732eac2d85c19810f4e84dbc0eaafb9d"
 Cache-Control: max-age=0, private, must-revalidate
-X-Request-Id: a87f1b44-150a-4ed0-b7da-9301fa1465b0
-X-Runtime: 0.093714
+X-Request-Id: 458d7b96-bb1a-469a-817e-4fd65c0f1db3
+X-Runtime: 0.125593
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
 Strict-Transport-Security: max-age=31536000
 
-{"data":[{"id":1,"account_id":1010,"registrant_id":null,"name":"example-alpha.com","unicode_name":"example-alpha.com","token":"domain-token","state":"hosted","auto_renew":false,"private_whois":false,"expires_on":null,"created_at":"2014-12-06T15:56:55Z","updated_at":"2015-12-09T00:20:56Z"},{"id":2,"account_id":1010,"registrant_id":21,"name":"example-beta.com","unicode_name":"example-beta.com","token":"domain-token","state":"registered","auto_renew":false,"private_whois":false,"expires_on":"2015-12-06","created_at":"2014-12-06T15:46:52Z","updated_at":"2015-12-09T00:20:53Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":2,"total_pages":1}}
+{"data":[{"id":181984,"account_id":1385,"registrant_id":2715,"name":"example-alpha.com","unicode_name":"example-alpha.com","state":"registered","auto_renew":false,"private_whois":false,"expires_on":"2021-06-05","expires_at":"2021-06-05T02:15:00Z","created_at":"2020-06-04T19:15:14Z","updated_at":"2020-06-04T19:15:21Z"},{"id":181985,"account_id":1385,"registrant_id":null,"name":"example-beta.com","unicode_name":"example-beta.com","state":"hosted","auto_renew":false,"private_whois":false,"expires_on":null,"expires_at":null,"created_at":"2020-06-04T19:47:05Z","updated_at":"2020-06-04T19:47:05Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":2,"total_pages":1}}


### PR DESCRIPTION
We deprecated expires_on attribute in our documentation and api in
favor of expires_at. This commit introduces the new field and removes
the old one. It also updates to use the new fixtures.

We should do a major bump, since we are removing an attribute.

Also synced these new fixtures with the docs one