### PR TITLE
Fix warning about ExvcrUtils

### DIFF
--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,11 +1,6 @@
 ExUnit.start()
 
 defmodule TestCase do
+  Code.require_file("test/exvcr_utils.exs")
   use ExUnit.CaseTemplate
-
-  setup do
-    Code.require_file("test/exvcr_utils.exs")
-    :ok
-  end
-
 end


### PR DESCRIPTION
By requiring code in `TestCase` definition rather than the setup block.