### PR TITLE
Implement registrar methods for Domain Prices API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   (dnsimple/dnsimple-elixir#135)
 - CHANGED: `Dnsimple.Certificate` struct now has `expires_at` (timestamp) to be used in favor of `expires_on` (date only).
   (dnsimple/dnsimple-elixir#137)
-- NEW: Added `Dnsimple.Registrar.get_domain_prices/3` to retrieve whether a domain is premium and the prices to register, transfer, and renew. (dnsimple/dnsimple-elixir#154)
+- NEW: Added `Dnsimple.Registrar.get_domain_prices` to retrieve whether a domain is premium and the prices to register, transfer, and renew. (dnsimple/dnsimple-elixir#154)
 
 ## Release 2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   (dnsimple/dnsimple-elixir#135)
 - CHANGED: `Dnsimple.Certificate` struct now has `expires_at` (timestamp) to be used in favor of `expires_on` (date only).
   (dnsimple/dnsimple-elixir#137)
+- NEW: Added `Dnsimple.Registrar.get_domain_prices/3` to retrieve whether a domain is premium and the prices to register, transfer, and renew. (dnsimple/dnsimple-elixir#154)
 
 ## Release 2.0.0
 

--- a/lib/dnsimple/domain_price.ex
+++ b/lib/dnsimple/domain_price.ex
@@ -1,0 +1,19 @@
+defmodule Dnsimple.DomainPrice do
+  @moduledoc """
+  Represents a domain price.
+
+  See:
+  - https://developer.dnsimple.com/v2/registrar/#getDomainPrices
+  """
+
+  @type t :: %__MODULE__{
+    domain: String.t,
+    premium: boolean,
+    registration_price: float,
+    renewal_price: float,
+    transfer_price: float
+  }
+
+  defstruct ~w(domain premium registration_price renewal_price transfer_price)a
+
+end

--- a/lib/dnsimple/registrar.ex
+++ b/lib/dnsimple/registrar.ex
@@ -14,6 +14,7 @@ defmodule Dnsimple.Registrar do
   alias Dnsimple.Response
   alias Dnsimple.DomainCheck
   alias Dnsimple.DomainPremiumPrice
+  alias Dnsimple.DomainPrice
   alias Dnsimple.DomainRegistration
   alias Dnsimple.DomainRenewal
   alias Dnsimple.DomainTransfer
@@ -47,7 +48,7 @@ defmodule Dnsimple.Registrar do
   Gets the premium price for a domain.
 
   See:
-  - https://developer.dnsimple.com/v2/registrar/#premium-price
+  - https://developer.dnsimple.com/v2/registrar/#getDomainPremiumPrice
 
   ## Examples:
 
@@ -67,12 +68,30 @@ defmodule Dnsimple.Registrar do
     |> Response.parse(%{"data" => %DomainPremiumPrice{}})
   end
 
+  @doc """
+  Get prices for a domain.
+
+  See:
+  - https://developer.dnsimple.com/v2/registrar/#getDomainPrices
+
+  ## Examples:
+
+      client = %Dnsimple.Client{access_token: "a1b2c3d4"}
+      {:ok, response} = Dnsimple.Registrar.get_domain_prices(client, account_id = "1010", domain_id = "example.com")
+  """
+  @spec get_domain_prices(Client.t, String.t, String.t, keyword()) :: {:ok|:error, Response.t}
+  def get_domain_prices(client, account_id, domain_name, options \\ []) do
+    url = Client.versioned("/#{account_id}/registrar/domains/#{domain_name}/prices")
+
+    Client.get(client, url, options)
+    |> Response.parse(%{"data" => %DomainPrice{}})
+  end
 
   @doc """
   Registers a domain.
 
   See:
-  - https://developer.dnsimple.com/v2/registrar/#register
+  - https://developer.dnsimple.com/v2/registrar/#registerDomain
 
   ## Examples:
 
@@ -97,7 +116,7 @@ defmodule Dnsimple.Registrar do
   Renews a domain.
 
   See:
-  - https://developer.dnsimple.com/v2/registrar/#renew
+  - https://developer.dnsimple.com/v2/registrar/#renewDomain
 
   ## Examples:
 
@@ -119,7 +138,7 @@ defmodule Dnsimple.Registrar do
   Starts the transfer of a domain to DNSimple.
 
   See:
-  - https://developer.dnsimple.com/v2/registrar/#transfer
+  - https://developer.dnsimple.com/v2/registrar/#transferDomain
 
   ## Examples:
 
@@ -185,7 +204,7 @@ defmodule Dnsimple.Registrar do
   Requests the transfer of a domain out of DNSimple.
 
   See:
-  - https://developer.dnsimple.com/v2/registrar/#transfer_out
+  - https://developer.dnsimple.com/v2/registrar/#authorizeDomainTransferOut
 
   ## Examples:
 
@@ -206,7 +225,7 @@ defmodule Dnsimple.Registrar do
   Enables auto-renewal for the domain.
 
   See:
-  - https://developer.dnsimple.com/v2/registrar/auto-renewal/#enable
+  - https://developer.dnsimple.com/v2/registrar/auto-renewal/#enableDomainAutoRenewal
 
   ## Examples:
 
@@ -227,7 +246,7 @@ defmodule Dnsimple.Registrar do
   Disables auto-renewal for the domain.
 
   See:
-  - https://developer.dnsimple.com/v2/registrar/auto-renewal/#disable
+  - https://developer.dnsimple.com/v2/registrar/auto-renewal/#disableDomainAutoRenewal
 
   ## Examples:
 
@@ -248,7 +267,7 @@ defmodule Dnsimple.Registrar do
   Returns the whois privacy of the domain.
 
   See:
-  - https://developer.dnsimple.com/v2/registrar/whois-privacy/#get
+  - https://developer.dnsimple.com/v2/registrar/whois-privacy/#getWhoisPrivacy
 
   ## Examples:
 
@@ -269,7 +288,7 @@ defmodule Dnsimple.Registrar do
   Enables whois privacy for the domain.
 
   See:
-  - https://developer.dnsimple.com/v2/registrar/whois-privacy/#enable
+  - https://developer.dnsimple.com/v2/registrar/whois-privacy/#enableWhoisPrivacy
 
   ## Examples:
 
@@ -290,7 +309,7 @@ defmodule Dnsimple.Registrar do
   Disables whois privacy for the domain.
 
   See:
-  - https://developer.dnsimple.com/v2/registrar/whois-privacy/#disable
+  - https://developer.dnsimple.com/v2/registrar/whois-privacy/#disableWhoisPrivacy
 
   ## Examples:
 
@@ -311,7 +330,7 @@ defmodule Dnsimple.Registrar do
   Renews whois privacy for the domain.
 
   See:
-  - https://developer.dnsimple.com/v2/registrar/whois-privacy/#renew
+  - https://developer.dnsimple.com/v2/registrar/whois-privacy/#renewWhoisPrivacy
 
   ## Examples:
 
@@ -332,7 +351,7 @@ defmodule Dnsimple.Registrar do
   Returns the name servers the domain is delegating to.
 
   See:
-  - https://developer.dnsimple.com/v2/registrar/delegation/#list
+  - https://developer.dnsimple.com/v2/registrar/delegation/#getDomainDelegation
 
   ## Examples:
 
@@ -353,7 +372,7 @@ defmodule Dnsimple.Registrar do
   Changes the domain's name servers and returns them.
 
   See:
-  - https://developer.dnsimple.com/v2/registrar/delegation/#update
+  - https://developer.dnsimple.com/v2/registrar/delegation/#changeDomainDelegation
 
   ## Examples:
 
@@ -379,7 +398,7 @@ defmodule Dnsimple.Registrar do
   Delegates the domain to vanity name servers.
 
   See:
-  - https://developer.dnsimple.com/v2/registrar/delegation/#delegateToVanity
+  - https://developer.dnsimple.com/v2/registrar/delegation/#changeDomainDelegationToVanity
 
   ## Examples:
 
@@ -407,7 +426,7 @@ defmodule Dnsimple.Registrar do
   registrar of the domain).
 
   See:
-  - https://developer.dnsimple.com/v2/registrar/delegation/#dedelegateFromVanity
+  - https://developer.dnsimple.com/v2/registrar/delegation/#changeDomainDelegationFromVanity
 
   ## Examples:
 

--- a/test/dnsimple/registrar_test.exs
+++ b/test/dnsimple/registrar_test.exs
@@ -61,7 +61,7 @@ defmodule Dnsimple.RegistrarTest do
   describe ".get_domain_prices" do
     test "returns the result in a Dnsimple.Response for the domain" do
       url = "#{@client.base_url}/v2/#{@account_id}/registrar/domains/bingo.pizza/prices"
-      fixture = "getdomainPrices/success.http"
+      fixture = "getDomainPrices/success.http"
 
       use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: "get", url: url) do
         {:ok, response} = @module.get_domain_prices(@client, @account_id, "bingo.pizza")

--- a/test/fixtures.http/getDomainPrices/failure.http
+++ b/test/fixtures.http/getDomainPrices/failure.http
@@ -1,0 +1,19 @@
+HTTP/1.1 400 Bad Request
+Server: nginx
+Date: Mon, 08 Mar 2021 14:35:58 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2396
+X-RateLimit-Reset: 1615217645
+Cache-Control: no-cache
+X-Request-Id: e414a674-63bb-4e54-b714-db5b516bb190
+X-Runtime: 0.009579
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+Content-Security-Policy: frame-ancestors 'none'
+
+{"message":"TLD .PINEAPPLE is not supported"}

--- a/test/fixtures.http/getDomainPrices/success.http
+++ b/test/fixtures.http/getDomainPrices/success.http
@@ -1,0 +1,21 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Mon, 08 Mar 2021 14:35:26 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2397
+X-RateLimit-Reset: 1615217645
+ETag: W/"2104f27f2877f429295359cfc409f9f7"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: b0d9e000-58a6-4254-af43-8735d26e12d9
+X-Runtime: 9.129301
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+Content-Security-Policy: frame-ancestors 'none'
+Strict-Transport-Security: max-age=31536000
+
+{"data":{"domain":"bingo.pizza","premium":true,"registration_price":20.0,"renewal_price":20.0,"transfer_price":20.0}}


### PR DESCRIPTION
This commit introduces a new client method for our Domain Prices API:
- Registrar.get_domain_prices - Retrieves the prices for a domain.

It also includes if the domain is premium or not in the response.