### PR TITLE
Update Fixtures with the removal of Transfer-Encoding

### DIFF
--- a/test/dnsimple/domains_test.exs
+++ b/test/dnsimple/domains_test.exs
@@ -345,22 +345,22 @@ defmodule Dnsimple.DomainsTest do
 
   describe ".get_email_forward" do
     test "returns the email forward in a Dnsimple.Response" do
-      url     = "#{@client.base_url}/v2/#{@account_id}/domains/#{@domain_id}/email_forwards/17706"
+      url     = "#{@client.base_url}/v2/#{@account_id}/domains/#{@domain_id}/email_forwards/41872"
       method  = "get"
       fixture = "getEmailForward/success.http"
 
       use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url) do
-        {:ok, response} = @module.get_email_forward(@client, @account_id, @domain_id, _email_forward_id = 17706)
+        {:ok, response} = @module.get_email_forward(@client, @account_id, @domain_id, _email_forward_id = 41872)
         assert response.__struct__ == Dnsimple.Response
 
         data = response.data
         assert data.__struct__ == Dnsimple.EmailForward
-        assert data.id == 17706
-        assert data.domain_id == 228963
-        assert data.from == "jim@a-domain.com"
-        assert data.to == "jim@another.com"
-        assert data.created_at == "2016-02-04T14:26:50Z"
-        assert data.updated_at == "2016-02-04T14:26:50Z"
+        assert data.id == 41872
+        assert data.domain_id == 235146
+        assert data.from == "example@dnsimple.xyz"
+        assert data.to == "example@example.com"
+        assert data.created_at == "2021-01-25T13:54:40Z"
+        assert data.updated_at == "2021-01-25T13:54:40Z"
       end
     end
   end

--- a/test/dnsimple/registrar_test.exs
+++ b/test/dnsimple/registrar_test.exs
@@ -140,50 +140,50 @@ defmodule Dnsimple.RegistrarTest do
 
   describe ".get_domain_transfer" do
     test "returns the domain transfer in a Dnsimple.Response" do
-      url         = "#{@client.base_url}/v2/#{@account_id}/registrar/domains/example.com/transfers/358"
+      url         = "#{@client.base_url}/v2/#{@account_id}/registrar/domains/example.com/transfers/361"
       method      = "get"
       fixture     = "getDomainTransfer/success.http"
 
       use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url) do
-        {:ok, response} = @module.get_domain_transfer(@client, @account_id, "example.com", 358)
+        {:ok, response} = @module.get_domain_transfer(@client, @account_id, "example.com", 361)
         assert response.__struct__ == Dnsimple.Response
 
         data = response.data
         assert data.__struct__ == Dnsimple.DomainTransfer
-        assert data.id == 358
-        assert data.domain_id == 180716
-        assert data.registrant_id == 2459
+        assert data.id == 361
+        assert data.domain_id == 182245
+        assert data.registrant_id == 2715
         assert data.state == "cancelled"
         assert data.auto_renew == false
         assert data.whois_privacy == false
         assert data.status_description == "Canceled by customer"
-        assert data.created_at == "2020-05-18T16:54:15Z"
-        assert data.updated_at == "2020-05-18T17:00:02Z"
+        assert data.created_at == "2020-06-05T18:08:00Z"
+        assert data.updated_at == "2020-06-05T18:10:01Z"
       end
     end
   end
 
   describe ".cancel_domain_transfer" do
     test "returns the domain transfer in a Dnsimple.Response" do
-      url         = "#{@client.base_url}/v2/#{@account_id}/registrar/domains/example.com/transfers/358"
+      url         = "#{@client.base_url}/v2/#{@account_id}/registrar/domains/example.com/transfers/361"
       method      = "delete"
       fixture     = "cancelDomainTransfer/success.http"
 
       use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url) do
-        {:ok, response} = @module.cancel_domain_transfer(@client, @account_id, "example.com", 358)
+        {:ok, response} = @module.cancel_domain_transfer(@client, @account_id, "example.com", 361)
         assert response.__struct__ == Dnsimple.Response
 
         data = response.data
         assert data.__struct__ == Dnsimple.DomainTransfer
-        assert data.id == 358
-        assert data.domain_id == 180716
-        assert data.registrant_id == 2459
+        assert data.id == 361
+        assert data.domain_id == 182245
+        assert data.registrant_id == 2715
         assert data.state == "transferring"
         assert data.auto_renew == false
         assert data.whois_privacy == false
         assert data.status_description == nil
-        assert data.created_at == "2020-05-18T16:54:15Z"
-        assert data.updated_at == "2020-05-18T16:54:22Z"
+        assert data.created_at == "2020-06-05T18:08:00Z"
+        assert data.updated_at == "2020-06-05T18:08:04Z"
       end
     end
   end

--- a/test/exvcr_utils_test.exs
+++ b/test/exvcr_utils_test.exs
@@ -9,7 +9,6 @@ defmodule ExvcrUtilsTest do
     Server: nginx\r
     Date: Fri, 26 Feb 2016 16:04:05 GMT\r
     Content-Type: application/json; charset=utf-8\r
-    Transfer-Encoding: chunked\r
     Connection: keep-alive\r
     Status: 200 OK\r
     X-RateLimit-Limit: 4000\r

--- a/test/fixtures.http/accounts/success-account.http
+++ b/test/fixtures.http/accounts/success-account.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Tue, 14 Jun 2016 12:02:58 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2391

--- a/test/fixtures.http/accounts/success-user.http
+++ b/test/fixtures.http/accounts/success-user.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Tue, 14 Jun 2016 12:05:38 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2390

--- a/test/fixtures.http/addCollaborator/invite-success.http
+++ b/test/fixtures.http/addCollaborator/invite-success.http
@@ -2,7 +2,6 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Fri, 07 Oct 2016 08:51:12 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2398

--- a/test/fixtures.http/addCollaborator/success.http
+++ b/test/fixtures.http/addCollaborator/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Fri, 07 Oct 2016 08:53:41 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2397

--- a/test/fixtures.http/appliedServices/success.http
+++ b/test/fixtures.http/appliedServices/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Wed, 15 Jun 2016 11:09:44 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2398

--- a/test/fixtures.http/cancelDomainTransfer/success.http
+++ b/test/fixtures.http/cancelDomainTransfer/success.http
@@ -1,19 +1,18 @@
 HTTP/1.1 202 Accepted
 Server: nginx
-Date: Mon, 18 May 2020 16:55:35 GMT
+Date: Fri, 05 Jun 2020 18:09:42 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
-X-RateLimit-Remaining: 2398
-X-RateLimit-Reset: 1589824450
+X-RateLimit-Remaining: 2394
+X-RateLimit-Reset: 1591384034
 Cache-Control: no-cache
-X-Request-Id: c9ecfbd2-3db4-4550-a6d6-8dd9f5b68a06
-X-Runtime: 0.905412
+X-Request-Id: 3cf6dcfa-0bb5-439e-863a-af2ef08bc830
+X-Runtime: 0.912731
 X-Frame-Options: DENY
 X-Content-Type-Options: nosniff
 X-XSS-Protection: 1; mode=block
 X-Download-Options: noopen
 X-Permitted-Cross-Domain-Policies: none
 
-{"data":{"id":358,"domain_id":180716,"registrant_id":2459,"state":"transferring","auto_renew":false,"whois_privacy":false,"premium_price":null,"status_description":null,"created_at":"2020-05-18T16:54:15Z","updated_at":"2020-05-18T16:54:22Z"}}
+{"data":{"id":361,"domain_id":182245,"registrant_id":2715,"state":"transferring","auto_renew":false,"whois_privacy":false,"status_description":null,"created_at":"2020-06-05T18:08:00Z","updated_at":"2020-06-05T18:08:04Z"}}

--- a/test/fixtures.http/changeDomainDelegation/success.http
+++ b/test/fixtures.http/changeDomainDelegation/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Thu, 24 Mar 2016 11:17:01 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 2400

--- a/test/fixtures.http/changeDomainDelegationToVanity/success.http
+++ b/test/fixtures.http/changeDomainDelegationToVanity/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Mon, 11 Jul 2016 09:40:19 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2399

--- a/test/fixtures.http/checkDomain/success.http
+++ b/test/fixtures.http/checkDomain/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Fri, 26 Feb 2016 16:04:05 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 4000

--- a/test/fixtures.http/checkDomainPremiumPrice/error_400_not_a_premium_domain.http
+++ b/test/fixtures.http/checkDomainPremiumPrice/error_400_not_a_premium_domain.http
@@ -1,0 +1,18 @@
+HTTP/1.1 400 Bad Request
+Server: nginx
+Date: Mon, 27 Jul 2020 13:43:02 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 4800
+X-RateLimit-Remaining: 4786
+X-RateLimit-Reset: 1595859922
+Cache-Control: no-cache
+X-Request-Id: 382b409c-0f90-4758-af3b-0bccd31a9d0d
+X-Runtime: 1.346405
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+
+{"message":"`cocotero.love` is not a premium domain for registration"}

--- a/test/fixtures.http/checkDomainPremiumPrice/error_400_tld_not_supported.http
+++ b/test/fixtures.http/checkDomainPremiumPrice/error_400_tld_not_supported.http
@@ -1,0 +1,18 @@
+HTTP/1.1 400 Bad Request
+Server: nginx
+Date: Mon, 27 Jul 2020 13:41:23 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2398
+X-RateLimit-Reset: 1595860823
+Cache-Control: no-cache
+X-Request-Id: 6986cca3-4f57-4814-9e81-1c484d61c7ea
+X-Runtime: 0.007339
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+
+{"message":"TLD .LOVE is not supported"}

--- a/test/fixtures.http/checkDomainPremiumPrice/success.http
+++ b/test/fixtures.http/checkDomainPremiumPrice/success.http
@@ -1,0 +1,20 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Mon, 27 Jul 2020 13:58:50 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 4800
+X-RateLimit-Remaining: 4769
+X-RateLimit-Reset: 1595859923
+ETag: W/"54b4776b898065f2f551fc33465d0936"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 75c5090e-8000-4e95-a516-ffd09383f641
+X-Runtime: 2.380524
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+Strict-Transport-Security: max-age=31536000
+
+{"data":{"premium_price":"2640.00","action":"registration"}}

--- a/test/fixtures.http/checkZoneDistribution/error.http
+++ b/test/fixtures.http/checkZoneDistribution/error.http
@@ -2,7 +2,6 @@ HTTP/1.1 504 Gateway Timeout
 Server: nginx
 Date: Mon, 30 Oct 2017 09:09:41 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2399

--- a/test/fixtures.http/checkZoneDistribution/failure.http
+++ b/test/fixtures.http/checkZoneDistribution/failure.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Mon, 30 Oct 2017 09:09:41 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2399

--- a/test/fixtures.http/checkZoneDistribution/success.http
+++ b/test/fixtures.http/checkZoneDistribution/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Mon, 30 Oct 2017 09:09:41 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2399

--- a/test/fixtures.http/checkZoneRecordDistribution/error.http
+++ b/test/fixtures.http/checkZoneRecordDistribution/error.http
@@ -2,7 +2,6 @@ HTTP/1.1 504 Gateway Timeout
 Server: nginx
 Date: Mon, 18 Dec 2017 10:54:48 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2397

--- a/test/fixtures.http/checkZoneRecordDistribution/failure.http
+++ b/test/fixtures.http/checkZoneRecordDistribution/failure.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Mon, 18 Dec 2017 10:54:13 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2398

--- a/test/fixtures.http/checkZoneRecordDistribution/success.http
+++ b/test/fixtures.http/checkZoneRecordDistribution/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Mon, 18 Dec 2017 10:48:06 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2399

--- a/test/fixtures.http/createContact/created.http
+++ b/test/fixtures.http/createContact/created.http
@@ -2,7 +2,6 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Tue, 19 Jan 2016 20:50:26 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 201 Created
 X-RateLimit-Limit: 4000

--- a/test/fixtures.http/createDelegationSignerRecord/created.http
+++ b/test/fixtures.http/createDelegationSignerRecord/created.http
@@ -2,7 +2,6 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Fri, 03 Mar 2017 15:24:00 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2399

--- a/test/fixtures.http/createDelegationSignerRecord/validation-error.http
+++ b/test/fixtures.http/createDelegationSignerRecord/validation-error.http
@@ -2,7 +2,6 @@ HTTP/1.1 400 Bad Request
 Server: nginx
 Date: Fri, 03 Mar 2017 15:20:28 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2395

--- a/test/fixtures.http/createDomain/created.http
+++ b/test/fixtures.http/createDomain/created.http
@@ -2,7 +2,6 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Thu, 04 Jun 2020 19:47:05 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2378

--- a/test/fixtures.http/createEmailForward/created.http
+++ b/test/fixtures.http/createEmailForward/created.http
@@ -1,17 +1,21 @@
 HTTP/1.1 201 Created
 Server: nginx
-Date: Thu, 04 Feb 2016 14:26:51 GMT
+Date: Mon, 25 Jan 2021 13:54:40 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
-Status: 201 Created
-X-RateLimit-Limit: 4000
-X-RateLimit-Remaining: 3991
-X-RateLimit-Reset: 1454596042
-ETag: W/"10dd958c5a3a43eec0af1d8da655cab0"
+X-RateLimit-Limit: 4800
+X-RateLimit-Remaining: 4772
+X-RateLimit-Reset: 1611583415
+ETag: W/"80ad3ad1e115a8123193447fa003f68a"
 Cache-Control: max-age=0, private, must-revalidate
-X-Request-Id: fca523a2-aad9-49e6-a828-a0e7711a8501
-X-Runtime: 1.711621
+X-Request-Id: 1086590f-0e65-4010-8636-031400a662bf
+X-Runtime: 0.880228
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+Content-Security-Policy: frame-ancestors 'none'
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":17706,"domain_id":228963,"from":"jim@a-domain.com","to":"jim@another.com","created_at":"2016-02-04T14:26:50Z","updated_at":"2016-02-04T14:26:50Z"}}
+{"data":{"id":41872,"domain_id":235146,"alias_email":"example@dnsimple.xyz","destination_email":"example@example.com","created_at":"2021-01-25T13:54:40Z","updated_at":"2021-01-25T13:54:40Z","from":"example@dnsimple.xyz","to":"example@example.com"}}

--- a/test/fixtures.http/createPrimaryServer/created.http
+++ b/test/fixtures.http/createPrimaryServer/created.http
@@ -1,0 +1,21 @@
+HTTP/1.1 201 Created
+Server: nginx
+Date: Wed, 17 Mar 2021 23:08:42 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2388
+X-RateLimit-Reset: 1616024599
+ETag: W/"ceda02163217bdb9e6850e2c36cbf163"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 24ed1594-6701-475b-b66b-f85f9fe69736
+X-Runtime: 0.162800
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+Content-Security-Policy: frame-ancestors 'none'
+Strict-Transport-Security: max-age=31536000
+
+{"data":{"id":4,"account_id":531,"name":"PrimaryProduction","ip":"1.2.3.4","port":53,"linked_secondary_zones":[],"created_at":"2021-03-17T23:08:42Z","updated_at":"2021-03-17T23:08:42Z"}}

--- a/test/fixtures.http/createSecondaryZone/created.http
+++ b/test/fixtures.http/createSecondaryZone/created.http
@@ -1,0 +1,21 @@
+HTTP/1.1 201 Created
+Server: nginx
+Date: Wed, 17 Mar 2021 23:44:27 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2398
+X-RateLimit-Reset: 1616028241
+ETag: W/"9726e9abb694bb7a61777076d14158fd"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 967ead79-85e7-4950-aa70-52da90f9abcc
+X-Runtime: 0.294142
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+Content-Security-Policy: frame-ancestors 'none'
+Strict-Transport-Security: max-age=31536000
+
+{"data":{"id":734,"account_id":531,"name":"secondaryexample.com","reverse":false,"secondary":true,"last_transferred_at":null,"created_at":"2021-03-17T23:44:27Z","updated_at":"2021-03-17T23:44:27Z"}}

--- a/test/fixtures.http/createTemplate/created.http
+++ b/test/fixtures.http/createTemplate/created.http
@@ -2,7 +2,6 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Thu, 24 Mar 2016 11:09:16 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 201 Created
 X-RateLimit-Limit: 2400

--- a/test/fixtures.http/createTemplateRecord/created.http
+++ b/test/fixtures.http/createTemplateRecord/created.http
@@ -2,7 +2,6 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Tue, 03 May 2016 07:51:33 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 201 Created
 X-RateLimit-Limit: 2400

--- a/test/fixtures.http/createWebhook/created.http
+++ b/test/fixtures.http/createWebhook/created.http
@@ -2,7 +2,6 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Mon, 15 Feb 2016 17:04:38 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 201 Created
 X-RateLimit-Limit: 4000

--- a/test/fixtures.http/createZoneRecord/created-apex.http
+++ b/test/fixtures.http/createZoneRecord/created-apex.http
@@ -2,7 +2,6 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Thu, 07 Jan 2016 17:45:13 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 201 Created
 X-RateLimit-Limit: 4000

--- a/test/fixtures.http/createZoneRecord/created.http
+++ b/test/fixtures.http/createZoneRecord/created.http
@@ -2,7 +2,6 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Thu, 07 Jan 2016 17:45:13 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 201 Created
 X-RateLimit-Limit: 4000

--- a/test/fixtures.http/deleteContact/error-contact-in-use.http
+++ b/test/fixtures.http/deleteContact/error-contact-in-use.http
@@ -1,0 +1,18 @@
+HTTP/1.1 400 Bad Request
+Server: nginx
+Date: Wed, 11 Apr 2018 10:50:21 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2397
+X-RateLimit-Reset: 1523447401
+Cache-Control: no-cache
+X-Request-Id: 8d9f3de7-6e42-4a16-82eb-e2434dd58008
+X-Runtime: 0.271090
+X-Content-Type-Options: nosniff
+X-Download-Options: noopen
+X-Frame-Options: DENY
+X-Permitted-Cross-Domain-Policies: none
+X-XSS-Protection: 1; mode=block
+
+{"message":"The contact cannot be deleted because it's currently in use"}

--- a/test/fixtures.http/deleteEmailForward/success.http
+++ b/test/fixtures.http/deleteEmailForward/success.http
@@ -1,13 +1,18 @@
 HTTP/1.1 204 No Content
 Server: nginx
-Date: Thu, 04 Feb 2016 17:14:52 GMT
+Date: Mon, 25 Jan 2021 13:56:43 GMT
 Connection: keep-alive
-Status: 204 No Content
-X-RateLimit-Limit: 4000
-X-RateLimit-Remaining: 3999
-X-RateLimit-Reset: 1454609692
+X-RateLimit-Limit: 4800
+X-RateLimit-Remaining: 4765
+X-RateLimit-Reset: 1611583416
 Cache-Control: no-cache
-X-Request-Id: 716d181c-495d-47ab-ab79-391a70e8abe1
-X-Runtime: 0.145208
+X-Request-Id: bfaceb73-4fd3-4490-8528-472ec1df3526
+X-Runtime: 0.506670
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+Content-Security-Policy: frame-ancestors 'none'
 Strict-Transport-Security: max-age=31536000
 

--- a/test/fixtures.http/disableDnssec/not-enabled.http
+++ b/test/fixtures.http/disableDnssec/not-enabled.http
@@ -2,7 +2,6 @@ HTTP/1.1 428 Precondition Required
 Server: nginx
 Date: Fri, 03 Mar 2017 10:00:36 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2396

--- a/test/fixtures.http/disableWhoisPrivacy/success.http
+++ b/test/fixtures.http/disableWhoisPrivacy/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Sat, 13 Feb 2016 14:36:38 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 4000

--- a/test/fixtures.http/downloadCertificate/success.http
+++ b/test/fixtures.http/downloadCertificate/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Sat, 11 Jun 2016 18:53:48 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2396

--- a/test/fixtures.http/enableDnssec/success.http
+++ b/test/fixtures.http/enableDnssec/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Fri, 03 Mar 2017 13:49:58 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2398

--- a/test/fixtures.http/enableVanityNameServers/success.http
+++ b/test/fixtures.http/enableVanityNameServers/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Thu, 14 Jul 2016 13:22:17 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2399

--- a/test/fixtures.http/enableWhoisPrivacy/created.http
+++ b/test/fixtures.http/enableWhoisPrivacy/created.http
@@ -2,7 +2,6 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Sat, 13 Feb 2016 14:34:52 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 201 Created
 X-RateLimit-Limit: 4000

--- a/test/fixtures.http/enableWhoisPrivacy/success.http
+++ b/test/fixtures.http/enableWhoisPrivacy/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Sat, 13 Feb 2016 14:36:49 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 4000

--- a/test/fixtures.http/getCertificate/success.http
+++ b/test/fixtures.http/getCertificate/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Thu, 18 Jun 2020 19:16:29 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 4800
 X-RateLimit-Remaining: 4797

--- a/test/fixtures.http/getCertificatePrivateKey/success.http
+++ b/test/fixtures.http/getCertificatePrivateKey/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Sat, 11 Jun 2016 18:50:50 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2397

--- a/test/fixtures.http/getContact/success.http
+++ b/test/fixtures.http/getContact/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Tue, 19 Jan 2016 20:57:38 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 4000

--- a/test/fixtures.http/getDelegationSignerRecord/success.http
+++ b/test/fixtures.http/getDelegationSignerRecord/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Fri, 03 Mar 2017 13:53:06 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2396

--- a/test/fixtures.http/getDnssec/success.http
+++ b/test/fixtures.http/getDnssec/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Fri, 03 Mar 2017 09:58:37 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2398

--- a/test/fixtures.http/getDomain/success.http
+++ b/test/fixtures.http/getDomain/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Thu, 04 Jun 2020 19:37:22 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2379

--- a/test/fixtures.http/getDomainDelegation/success-empty.http
+++ b/test/fixtures.http/getDomainDelegation/success-empty.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Thu, 24 Mar 2016 11:13:41 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 2400

--- a/test/fixtures.http/getDomainDelegation/success.http
+++ b/test/fixtures.http/getDomainDelegation/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Thu, 24 Mar 2016 11:17:18 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 2400

--- a/test/fixtures.http/getDomainPremiumPrice/failure.http
+++ b/test/fixtures.http/getDomainPremiumPrice/failure.http
@@ -2,7 +2,6 @@ HTTP/1.1 400 Bad Request
 Server: nginx
 Date: Tue, 22 Nov 2016 10:48:27 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Cache-Control: no-cache
 X-Request-Id: 1304138f-0fc7-4845-b9ed-e3803409cb5a

--- a/test/fixtures.http/getDomainPremiumPrice/success.http
+++ b/test/fixtures.http/getDomainPremiumPrice/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Tue, 22 Nov 2016 10:46:17 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2399

--- a/test/fixtures.http/getDomainPrices/failure.http
+++ b/test/fixtures.http/getDomainPrices/failure.http
@@ -1,0 +1,19 @@
+HTTP/1.1 400 Bad Request
+Server: nginx
+Date: Mon, 08 Mar 2021 14:35:58 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2396
+X-RateLimit-Reset: 1615217645
+Cache-Control: no-cache
+X-Request-Id: e414a674-63bb-4e54-b714-db5b516bb190
+X-Runtime: 0.009579
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+Content-Security-Policy: frame-ancestors 'none'
+
+{"message":"TLD .PINEAPPLE is not supported"}

--- a/test/fixtures.http/getDomainPrices/success.http
+++ b/test/fixtures.http/getDomainPrices/success.http
@@ -1,0 +1,21 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Mon, 08 Mar 2021 14:35:26 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2397
+X-RateLimit-Reset: 1615217645
+ETag: W/"2104f27f2877f429295359cfc409f9f7"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: b0d9e000-58a6-4254-af43-8735d26e12d9
+X-Runtime: 9.129301
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+Content-Security-Policy: frame-ancestors 'none'
+Strict-Transport-Security: max-age=31536000
+
+{"data":{"domain":"bingo.pizza","premium":true,"registration_price":20.0,"renewal_price":20.0,"transfer_price":20.0}}

--- a/test/fixtures.http/getDomainTransfer/success.http
+++ b/test/fixtures.http/getDomainTransfer/success.http
@@ -1,16 +1,15 @@
 HTTP/1.1 200 OK
 Server: nginx
-Date: Mon, 18 May 2020 17:03:54 GMT
+Date: Fri, 05 Jun 2020 18:23:53 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
-X-RateLimit-Remaining: 2396
-X-RateLimit-Reset: 1589824450
-ETag: W/"9f81d47057f629dd921ccabff433ccac"
+X-RateLimit-Remaining: 2392
+X-RateLimit-Reset: 1591384034
+ETag: W/"80c5827934c13b1ca87a587d96e7d1e8"
 Cache-Control: max-age=0, private, must-revalidate
-X-Request-Id: 7af4e96b-471d-4619-a0b6-b5d0d7261e75
-X-Runtime: 0.060273
+X-Request-Id: 9f4959ee-06a9-488c-906e-27a570cafbbf
+X-Runtime: 0.078429
 X-Frame-Options: DENY
 X-Content-Type-Options: nosniff
 X-XSS-Protection: 1; mode=block
@@ -18,4 +17,4 @@ X-Download-Options: noopen
 X-Permitted-Cross-Domain-Policies: none
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":358,"domain_id":180716,"registrant_id":2459,"state":"cancelled","auto_renew":false,"whois_privacy":false,"premium_price":null,"status_description":"Canceled by customer","created_at":"2020-05-18T16:54:15Z","updated_at":"2020-05-18T17:00:02Z"}}
+{"data":{"id":361,"domain_id":182245,"registrant_id":2715,"state":"cancelled","auto_renew":false,"whois_privacy":false,"status_description":"Canceled by customer","created_at":"2020-06-05T18:08:00Z","updated_at":"2020-06-05T18:10:01Z"}}

--- a/test/fixtures.http/getEmailForward/success.http
+++ b/test/fixtures.http/getEmailForward/success.http
@@ -1,17 +1,21 @@
 HTTP/1.1 200 OK
 Server: nginx
-Date: Thu, 04 Feb 2016 14:42:46 GMT
+Date: Mon, 25 Jan 2021 13:56:24 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
-Status: 200 OK
-X-RateLimit-Limit: 4000
-X-RateLimit-Remaining: 3999
-X-RateLimit-Reset: 1454600566
-ETag: W/"10dd958c5a3a43eec0af1d8da655cab0"
+X-RateLimit-Limit: 4800
+X-RateLimit-Remaining: 4766
+X-RateLimit-Reset: 1611583416
+ETag: W/"80ad3ad1e115a8123193447fa003f68a"
 Cache-Control: max-age=0, private, must-revalidate
-X-Request-Id: fde15363-9332-4b91-bd8f-00b144eb8081
-X-Runtime: 0.022117
+X-Request-Id: 8f3a9517-f623-4d14-be2b-3f332a4d7873
+X-Runtime: 0.010653
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+Content-Security-Policy: frame-ancestors 'none'
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":17706,"domain_id":228963,"from":"jim@a-domain.com","to":"jim@another.com","created_at":"2016-02-04T14:26:50Z","updated_at":"2016-02-04T14:26:50Z"}}
+{"data":{"id":41872,"domain_id":235146,"alias_email":"example@dnsimple.xyz","destination_email":"example@example.com","created_at":"2021-01-25T13:54:40Z","updated_at":"2021-01-25T13:54:40Z","from":"example@dnsimple.xyz","to":"example@example.com"}}

--- a/test/fixtures.http/getPrimaryServer/success.http
+++ b/test/fixtures.http/getPrimaryServer/success.http
@@ -1,0 +1,21 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Wed, 17 Mar 2021 23:18:40 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2386
+X-RateLimit-Reset: 1616024599
+ETag: W/"ceda02163217bdb9e6850e2c36cbf163"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 259fc436-7146-4e6b-98fa-3c43f541482b
+X-Runtime: 0.033067
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+Content-Security-Policy: frame-ancestors 'none'
+Strict-Transport-Security: max-age=31536000
+
+{"data":{"id":4,"account_id":531,"name":"PrimaryProduction","ip":"1.2.3.4","port":53,"linked_secondary_zones":[],"created_at":"2021-03-17T23:08:42Z","updated_at":"2021-03-17T23:08:42Z"}}

--- a/test/fixtures.http/getService/success.http
+++ b/test/fixtures.http/getService/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Fri, 15 Apr 2016 14:50:13 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 2400

--- a/test/fixtures.http/getTemplate/success.http
+++ b/test/fixtures.http/getTemplate/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Tue, 22 Mar 2016 11:14:57 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 2400

--- a/test/fixtures.http/getTemplateRecord/success.http
+++ b/test/fixtures.http/getTemplateRecord/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Tue, 03 May 2016 08:04:20 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 2400

--- a/test/fixtures.http/getTld/success.http
+++ b/test/fixtures.http/getTld/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Fri, 23 Sep 2016 09:06:13 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2396

--- a/test/fixtures.http/getTldExtendedAttributes/success-attributes.http
+++ b/test/fixtures.http/getTldExtendedAttributes/success-attributes.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Sun, 28 Feb 2016 13:19:01 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 4000

--- a/test/fixtures.http/getTldExtendedAttributes/success-noattributes.http
+++ b/test/fixtures.http/getTldExtendedAttributes/success-noattributes.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Sun, 28 Feb 2016 13:19:18 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 4000

--- a/test/fixtures.http/getTldExtendedAttributes/success.http
+++ b/test/fixtures.http/getTldExtendedAttributes/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Sun, 28 Feb 2016 13:19:01 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 4000

--- a/test/fixtures.http/getWebhook/success.http
+++ b/test/fixtures.http/getWebhook/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Mon, 15 Feb 2016 17:06:09 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 4000

--- a/test/fixtures.http/getWhoisPrivacy/success.http
+++ b/test/fixtures.http/getWhoisPrivacy/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Sat, 13 Feb 2016 14:35:37 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 4000

--- a/test/fixtures.http/getZone/success.http
+++ b/test/fixtures.http/getZone/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Fri, 22 Jan 2016 16:54:14 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 4000

--- a/test/fixtures.http/getZoneFile/success.http
+++ b/test/fixtures.http/getZoneFile/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Wed, 20 Jul 2016 09:04:24 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2398

--- a/test/fixtures.http/getZoneRecord/success.http
+++ b/test/fixtures.http/getZoneRecord/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Wed, 05 Oct 2016 09:53:54 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2394

--- a/test/fixtures.http/initiatePush/success.http
+++ b/test/fixtures.http/initiatePush/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Thu, 11 Aug 2016 10:16:03 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2395

--- a/test/fixtures.http/issueLetsencryptCertificate/success.http
+++ b/test/fixtures.http/issueLetsencryptCertificate/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 202 Accepted
 Server: nginx
 Date: Thu, 18 Jun 2020 18:56:21 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 4800
 X-RateLimit-Remaining: 4798

--- a/test/fixtures.http/issueRenewalLetsencryptCertificate/success.http
+++ b/test/fixtures.http/issueRenewalLetsencryptCertificate/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 202 Accepted
 Server: nginx
 Date: Thu, 18 Jun 2020 20:05:26 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 4800
 X-RateLimit-Remaining: 4798

--- a/test/fixtures.http/linkPrimaryServer/success.http
+++ b/test/fixtures.http/linkPrimaryServer/success.http
@@ -1,0 +1,21 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Wed, 17 Mar 2021 23:29:51 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2384
+X-RateLimit-Reset: 1616024598
+ETag: W/"911f7a8bf729e066d3d0aedce7eaab4e"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 104a8bbe-a4a7-41b1-9d51-499596f5b228
+X-Runtime: 0.249251
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+Content-Security-Policy: frame-ancestors 'none'
+Strict-Transport-Security: max-age=31536000
+
+{"data":{"id":4,"account_id":531,"name":"PrimaryProduction","ip":"1.2.3.4","port":53,"linked_secondary_zones":["secondaryzone.com"],"created_at":"2021-03-17T23:08:42Z","updated_at":"2021-03-17T23:08:42Z"}}

--- a/test/fixtures.http/listAccounts/success-account.http
+++ b/test/fixtures.http/listAccounts/success-account.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Tue, 14 Jun 2016 12:02:58 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2391

--- a/test/fixtures.http/listAccounts/success-user.http
+++ b/test/fixtures.http/listAccounts/success-user.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Tue, 14 Jun 2016 12:05:38 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2390

--- a/test/fixtures.http/listCertificates/success.http
+++ b/test/fixtures.http/listCertificates/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Thu, 18 Jun 2020 20:35:23 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 4800
 X-RateLimit-Remaining: 4797

--- a/test/fixtures.http/listCollaborators/success.http
+++ b/test/fixtures.http/listCollaborators/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Fri, 07 Oct 2016 08:58:05 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2396

--- a/test/fixtures.http/listContacts/success.http
+++ b/test/fixtures.http/listContacts/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Tue, 19 Jan 2016 18:35:01 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 4000

--- a/test/fixtures.http/listDelegationSignerRecords/success.http
+++ b/test/fixtures.http/listDelegationSignerRecords/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Fri, 03 Mar 2017 13:50:42 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2397

--- a/test/fixtures.http/listDomains/success.http
+++ b/test/fixtures.http/listDomains/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Thu, 04 Jun 2020 19:54:16 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2399

--- a/test/fixtures.http/listEmailForwards/success.http
+++ b/test/fixtures.http/listEmailForwards/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Thu, 04 Feb 2016 14:07:19 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 4000

--- a/test/fixtures.http/listPrimaryServers/success.http
+++ b/test/fixtures.http/listPrimaryServers/success.http
@@ -1,0 +1,21 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Wed, 17 Mar 2021 22:45:37 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2394
+X-RateLimit-Reset: 1616024598
+ETag: W/"1a8276fb3483d6954afe139480753c5b"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 411f7b7c-3ebb-4b6a-a986-5ffd8dcd4144
+X-Runtime: 0.159587
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+Content-Security-Policy: frame-ancestors 'none'
+Strict-Transport-Security: max-age=31536000
+
+{"data":[{"id":1,"account_id":531,"name":"Primary","ip":"1.1.1.1","port":4567,"linked_secondary_zones":[],"created_at":"2021-03-05T18:02:23Z","updated_at":"2021-03-05T18:02:23Z"},{"id":2,"account_id":531,"name":"Primary Production","ip":"1.1.1.1","port":4567,"linked_secondary_zones":["secondaryzone.com"],"created_at":"2021-03-16T20:33:34Z","updated_at":"2021-03-16T20:33:34Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":2,"total_pages":1}}

--- a/test/fixtures.http/listPushes/success.http
+++ b/test/fixtures.http/listPushes/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Thu, 11 Aug 2016 10:19:54 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2393

--- a/test/fixtures.http/listServices/success.http
+++ b/test/fixtures.http/listServices/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Sat, 10 Dec 2016 22:37:13 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2399

--- a/test/fixtures.http/listTemplateRecords/success.http
+++ b/test/fixtures.http/listTemplateRecords/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Tue, 03 May 2016 08:07:17 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 2400

--- a/test/fixtures.http/listTemplates/success.http
+++ b/test/fixtures.http/listTemplates/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Tue, 22 Mar 2016 11:11:50 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 2400

--- a/test/fixtures.http/listTlds/success.http
+++ b/test/fixtures.http/listTlds/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Fri, 23 Sep 2016 08:22:50 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2397

--- a/test/fixtures.http/listWebhooks/success.http
+++ b/test/fixtures.http/listWebhooks/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Mon, 15 Feb 2016 17:06:21 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 4000

--- a/test/fixtures.http/listZoneRecords/success.http
+++ b/test/fixtures.http/listZoneRecords/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Wed, 05 Oct 2016 09:27:02 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2397

--- a/test/fixtures.http/listZones/success.http
+++ b/test/fixtures.http/listZones/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Fri, 22 Jan 2016 16:54:24 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 4000

--- a/test/fixtures.http/method-not-allowed.http
+++ b/test/fixtures.http/method-not-allowed.http
@@ -1,7 +1,6 @@
 HTTP/1.1 405 Method Not Allowed
 Server: nginx
 Date: Fri, 15 Apr 2016 14:15:04 GMT
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 405 Method Not Allowed
 Allow: DELETE, GET, HEAD, PATCH, POST

--- a/test/fixtures.http/notfound-certificate.http
+++ b/test/fixtures.http/notfound-certificate.http
@@ -2,7 +2,6 @@ HTTP/1.1 404 Not Found
 Server: nginx
 Date: Tue, 19 Jul 2016 08:56:34 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Cache-Control: no-cache
 X-Request-Id: 9a51fa7e-cc9b-498b-bf8d-ee3b2819c0c6

--- a/test/fixtures.http/notfound-collaborator.http
+++ b/test/fixtures.http/notfound-collaborator.http
@@ -2,7 +2,6 @@ HTTP/1.1 404 Not Found
 Server: nginx
 Date: Mon, 21 Nov 2016 09:32:48 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Cache-Control: no-cache
 X-Request-Id: 3e76b10b-412c-42ef-87d1-f8ff327df997

--- a/test/fixtures.http/notfound-contact.http
+++ b/test/fixtures.http/notfound-contact.http
@@ -2,7 +2,6 @@ HTTP/1.1 404 Not Found
 Server: nginx
 Date: Tue, 19 Jan 2016 21:04:48 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 404 Not Found
 Cache-Control: no-cache

--- a/test/fixtures.http/notfound-delegationSignerRecord.http
+++ b/test/fixtures.http/notfound-delegationSignerRecord.http
@@ -2,7 +2,6 @@ HTTP/1.1 404 Not Found
 Server: nginx
 Date: Thu, 04 Feb 2016 14:44:56 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 404 Not Found
 Cache-Control: no-cache

--- a/test/fixtures.http/notfound-domain.http
+++ b/test/fixtures.http/notfound-domain.http
@@ -2,7 +2,6 @@ HTTP/1.1 404 Not Found
 Server: nginx
 Date: Wed, 16 Dec 2015 22:07:20 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Strict-Transport-Security: max-age=31536000
 Cache-Control: no-cache

--- a/test/fixtures.http/notfound-domainpush.http
+++ b/test/fixtures.http/notfound-domainpush.http
@@ -2,7 +2,6 @@ HTTP/1.1 404 Not Found
 Server: nginx
 Date: Thu, 04 Feb 2016 14:44:56 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 404 Not Found
 Cache-Control: no-cache

--- a/test/fixtures.http/notfound-emailforward.http
+++ b/test/fixtures.http/notfound-emailforward.http
@@ -2,7 +2,6 @@ HTTP/1.1 404 Not Found
 Server: nginx
 Date: Thu, 04 Feb 2016 14:44:56 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 404 Not Found
 Cache-Control: no-cache

--- a/test/fixtures.http/notfound-record.http
+++ b/test/fixtures.http/notfound-record.http
@@ -2,7 +2,6 @@ HTTP/1.1 404 Not Found
 Server: nginx
 Date: Fri, 22 Jan 2016 16:46:07 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 404 Not Found
 Cache-Control: no-cache

--- a/test/fixtures.http/notfound-template.http
+++ b/test/fixtures.http/notfound-template.http
@@ -2,7 +2,6 @@ HTTP/1.1 404 Not Found
 Server: nginx
 Date: Wed, 04 May 2016 09:35:45 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 404 Not Found
 Cache-Control: no-cache

--- a/test/fixtures.http/notfound-webhook.http
+++ b/test/fixtures.http/notfound-webhook.http
@@ -2,7 +2,6 @@ HTTP/1.1 404 Not Found
 Server: nginx
 Date: Thu, 03 Mar 2016 11:55:29 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 404 Not Found
 Cache-Control: no-cache

--- a/test/fixtures.http/notfound-whoisprivacy.http
+++ b/test/fixtures.http/notfound-whoisprivacy.http
@@ -2,7 +2,6 @@ HTTP/1.1 404 Not Found
 Server: nginx
 Date: Sat, 13 Feb 2016 14:34:32 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 404 Not Found
 Cache-Control: no-cache

--- a/test/fixtures.http/notfound-zone.http
+++ b/test/fixtures.http/notfound-zone.http
@@ -2,7 +2,6 @@ HTTP/1.1 404 Not Found
 Server: nginx
 Date: Fri, 22 Jan 2016 16:46:02 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 404 Not Found
 Cache-Control: no-cache

--- a/test/fixtures.http/oauthAccessToken/error-invalid-request.http
+++ b/test/fixtures.http/oauthAccessToken/error-invalid-request.http
@@ -2,7 +2,6 @@ HTTP/1.1 400 Bad Request
 Server: nginx
 Date: Mon, 08 Feb 2016 21:24:19 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 30
 X-RateLimit-Remaining: 29

--- a/test/fixtures.http/oauthAccessToken/success.http
+++ b/test/fixtures.http/oauthAccessToken/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Mon, 08 Feb 2016 21:24:19 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 30

--- a/test/fixtures.http/pages-1of3.http
+++ b/test/fixtures.http/pages-1of3.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Wed, 16 Dec 2015 13:36:11 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 4000
 X-RateLimit-Remaining: 3997

--- a/test/fixtures.http/pages-2of3.http
+++ b/test/fixtures.http/pages-2of3.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Wed, 16 Dec 2015 13:36:11 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 4000
 X-RateLimit-Remaining: 3997

--- a/test/fixtures.http/pages-3of3.http
+++ b/test/fixtures.http/pages-3of3.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Wed, 16 Dec 2015 13:36:11 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 4000
 X-RateLimit-Remaining: 3997

--- a/test/fixtures.http/purchaseLetsencryptCertificate/success.http
+++ b/test/fixtures.http/purchaseLetsencryptCertificate/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Thu, 18 Jun 2020 18:54:17 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 4800
 X-RateLimit-Remaining: 4799

--- a/test/fixtures.http/purchaseRenewalLetsencryptCertificate/success.http
+++ b/test/fixtures.http/purchaseRenewalLetsencryptCertificate/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Thu, 18 Jun 2020 19:56:20 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: identity
 Connection: keep-alive
 X-RateLimit-Limit: 4800
 X-RateLimit-Remaining: 4799

--- a/test/fixtures.http/registerDomain/success.http
+++ b/test/fixtures.http/registerDomain/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Fri, 09 Dec 2016 19:35:38 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2396
@@ -18,4 +17,4 @@ X-Permitted-Cross-Domain-Policies: none
 X-XSS-Protection: 1; mode=block
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":1,"domain_id":999,"registrant_id":2,"period":1,"state":"new","auto_renew":false,"whois_privacy":false,"premium_price":null,"created_at":"2016-12-09T19:35:31Z","updated_at":"2016-12-09T19:35:31Z"}}
+{"data":{"id":1,"domain_id":999,"registrant_id":2,"period":1,"state":"new","auto_renew":false,"whois_privacy":false,"created_at":"2016-12-09T19:35:31Z","updated_at":"2016-12-09T19:35:31Z"}}

--- a/test/fixtures.http/renewDomain/error-tooearly.http
+++ b/test/fixtures.http/renewDomain/error-tooearly.http
@@ -2,7 +2,6 @@ HTTP/1.1 400 Bad Request
 Server: nginx
 Date: Mon, 15 Feb 2016 15:06:35 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 400 Bad Request
 X-RateLimit-Limit: 4000

--- a/test/fixtures.http/renewDomain/success.http
+++ b/test/fixtures.http/renewDomain/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Fri, 09 Dec 2016 19:46:57 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2394
@@ -18,4 +17,4 @@ X-Permitted-Cross-Domain-Policies: none
 X-XSS-Protection: 1; mode=block
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":1,"domain_id":999,"period":1,"state":"new","premium_price":null,"created_at":"2016-12-09T19:46:45Z","updated_at":"2016-12-09T19:46:45Z"}}
+{"data":{"id":1,"domain_id":999,"period":1,"state":"new","created_at":"2016-12-09T19:46:45Z","updated_at":"2016-12-09T19:46:45Z"}}

--- a/test/fixtures.http/renewWhoisPrivacy/success.http
+++ b/test/fixtures.http/renewWhoisPrivacy/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Thu, 10 Jan 2019 12:12:50 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2398

--- a/test/fixtures.http/renewWhoisPrivacy/whois-privacy-duplicated-order.http
+++ b/test/fixtures.http/renewWhoisPrivacy/whois-privacy-duplicated-order.http
@@ -2,7 +2,6 @@ HTTP/1.1 400 Bad Request
 Server: nginx
 Date: Thu, 10 Jan 2019 12:13:21 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2397

--- a/test/fixtures.http/renewWhoisPrivacy/whois-privacy-not-found.http
+++ b/test/fixtures.http/renewWhoisPrivacy/whois-privacy-not-found.http
@@ -2,7 +2,6 @@ HTTP/1.1 400 Bad Request
 Server: nginx
 Date: Thu, 10 Jan 2019 12:11:39 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2399

--- a/test/fixtures.http/response.http
+++ b/test/fixtures.http/response.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Fri, 18 Dec 2015 15:19:37 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 4000
 X-RateLimit-Remaining: 3991

--- a/test/fixtures.http/transferDomain/error-indnsimple.http
+++ b/test/fixtures.http/transferDomain/error-indnsimple.http
@@ -2,7 +2,6 @@ HTTP/1.1 400 Bad Request
 Server: nginx
 Date: Sun, 21 Feb 2016 13:11:54 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 400 Bad Request
 X-RateLimit-Limit: 4000

--- a/test/fixtures.http/transferDomain/error-missing-authcode.http
+++ b/test/fixtures.http/transferDomain/error-missing-authcode.http
@@ -2,7 +2,6 @@ HTTP/1.1 400 Bad Request
 Server: nginx
 Date: Sun, 21 Feb 2016 13:11:11 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 400 Bad Request
 X-RateLimit-Limit: 4000

--- a/test/fixtures.http/transferDomain/success.http
+++ b/test/fixtures.http/transferDomain/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 201 Created
 Server: nginx
 Date: Fri, 09 Dec 2016 19:43:43 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2395
@@ -18,4 +17,4 @@ X-Permitted-Cross-Domain-Policies: none
 X-XSS-Protection: 1; mode=block
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":1,"domain_id":999,"registrant_id":2,"state":"transferring","auto_renew":false,"whois_privacy":false,"premium_price":null,"created_at":"2016-12-09T19:43:41Z","updated_at":"2016-12-09T19:43:43Z"}}
+{"data":{"id":1,"domain_id":999,"registrant_id":2,"state":"transferring","auto_renew":false,"whois_privacy":false,"created_at":"2016-12-09T19:43:41Z","updated_at":"2016-12-09T19:43:43Z"}}

--- a/test/fixtures.http/unlinkPrimaryServer/success.http
+++ b/test/fixtures.http/unlinkPrimaryServer/success.http
@@ -1,0 +1,21 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Wed, 17 Mar 2021 23:36:43 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2383
+X-RateLimit-Reset: 1616024599
+ETag: W/"ceda02163217bdb9e6850e2c36cbf163"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 789c6feb-63e1-40d6-b2b6-f569b23a507c
+X-Runtime: 0.270968
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+Content-Security-Policy: frame-ancestors 'none'
+Strict-Transport-Security: max-age=31536000
+
+{"data":{"id":4,"account_id":531,"name":"PrimaryProduction","ip":"1.2.3.4","port":53,"linked_secondary_zones":[],"created_at":"2021-03-17T23:08:42Z","updated_at":"2021-03-17T23:08:42Z"}}

--- a/test/fixtures.http/updateContact/success.http
+++ b/test/fixtures.http/updateContact/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Tue, 19 Jan 2016 21:28:13 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 4000

--- a/test/fixtures.http/updateTemplate/success.http
+++ b/test/fixtures.http/updateTemplate/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Thu, 24 Mar 2016 11:04:55 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 Status: 200 OK
 X-RateLimit-Limit: 2400

--- a/test/fixtures.http/updateZoneRecord/success.http
+++ b/test/fixtures.http/updateZoneRecord/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Wed, 05 Oct 2016 09:59:48 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2393

--- a/test/fixtures.http/validation-error.http
+++ b/test/fixtures.http/validation-error.http
@@ -2,7 +2,6 @@ HTTP/1.1 400 Bad Request
 Server: nginx
 Date: Wed, 23 Nov 2016 08:12:57 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 2400
 X-RateLimit-Remaining: 2396

--- a/test/fixtures.http/whoami/success-account.http
+++ b/test/fixtures.http/whoami/success-account.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Fri, 18 Dec 2015 15:19:37 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 4000
 X-RateLimit-Remaining: 3991

--- a/test/fixtures.http/whoami/success-user.http
+++ b/test/fixtures.http/whoami/success-user.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Fri, 18 Dec 2015 15:19:37 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 4000
 X-RateLimit-Remaining: 3991

--- a/test/fixtures.http/whoami/success.http
+++ b/test/fixtures.http/whoami/success.http
@@ -2,7 +2,6 @@ HTTP/1.1 200 OK
 Server: nginx
 Date: Fri, 18 Dec 2015 15:19:37 GMT
 Content-Type: application/json; charset=utf-8
-Transfer-Encoding: chunked
 Connection: keep-alive
 X-RateLimit-Limit: 4000
 X-RateLimit-Remaining: 3991


### PR DESCRIPTION
After dnsimple/dnsimple-developer#337 we removed
the Transfer-Encoding from the fixtures.

This commit updates the project fixtures with the most recent ones.