### PR TITLE
Remove deprecated expires_on attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## main
 
+- REMOVED: Deprecated attribute `expires_on` has been rmeoved from `Dnsimple.Domain` (dnsimple/dnsimple-elixir#156)
 - CHANGED: Fix warning about ExvcrUtils (dnsimple/dnsimple-elixir#139)
 - CHANGED: `Dnsimple.Domain` struct now has `expires_at` (timestamp) to be used in favor of `expires_on` (date only).
   (dnsimple/dnsimple-elixir#135)

--- a/lib/dnsimple/certificate.ex
+++ b/lib/dnsimple/certificate.ex
@@ -13,7 +13,6 @@ defmodule Dnsimple.Certificate do
   - https://developer.dnsimple.com/v2/certificates/#certificate-attributes
   """
 
-  @doc "expires_on is deprecated in favor of expires_at"
   @type t :: %__MODULE__{
     id: integer,
     domain_id: integer,
@@ -28,7 +27,6 @@ defmodule Dnsimple.Certificate do
     created_at: String.t,
     updated_at: String.t,
     expires_at: String.t,
-    expires_on: String.t,
 
     private_key: String.t,
     server: String.t,
@@ -38,7 +36,7 @@ defmodule Dnsimple.Certificate do
 
   defstruct ~w(id domain_id contact_id
                common_name alternate_names years csr state authority_identifier auto_renew
-               created_at updated_at expires_at expires_on
+               created_at updated_at expires_at
                server root chain private_key)a
 
 end

--- a/lib/dnsimple/domain.ex
+++ b/lib/dnsimple/domain.ex
@@ -7,7 +7,6 @@ defmodule Dnsimple.Domain do
   - https://developer.dnsimple.com/v2/domains/#domain-attributes
   """
 
-  @doc "expires_on is deprecated in favor of expires_at"
   @type t :: %__MODULE__{
     id: integer,
     account_id: integer,
@@ -19,11 +18,10 @@ defmodule Dnsimple.Domain do
     auto_renew: boolean,
     private_whois: boolean,
     expires_at: String.t,
-    expires_on: String.t,
     created_at: String.t,
     updated_at: String.t,
   }
 
   defstruct ~w(id account_id registrant_id name unicode_name token state
-               auto_renew private_whois expires_at expires_on created_at updated_at)a
+               auto_renew private_whois expires_at created_at updated_at)a
 end

--- a/test/dnsimple/certificates_test.exs
+++ b/test/dnsimple/certificates_test.exs
@@ -66,7 +66,6 @@ defmodule Dnsimple.CertificatesTest do
         assert data.common_name == "www.bingo.pizza"
         assert data.alternate_names == []
         assert data.auto_renew == false
-        assert data.expires_on == "2020-09-16"
         assert data.expires_at == "2020-09-16T18:10:13Z"
       end
     end

--- a/test/dnsimple/domains_test.exs
+++ b/test/dnsimple/domains_test.exs
@@ -86,7 +86,6 @@ defmodule Dnsimple.DomainsTest do
         assert data.auto_renew == false
         assert data.private_whois == false
         assert data.expires_at == "2021-06-05T02:15:00Z"
-        assert data.expires_on == "2021-06-05"
         assert data.created_at == "2020-06-04T19:15:14Z"
         assert data.updated_at == "2020-06-04T19:15:21Z"
       end


### PR DESCRIPTION
This commit drops the deprecated expires_on from Domain and Certificate.
This attribute was deprecated in favor of expires_at.

Since we will make a major release, I think it makes sense to drop this deprecated attributes