### PR TITLE
Update supported elixir versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,40 @@
 language: elixir
 
 elixir:
-  - "1.6"
-  - "1.7"
   - "1.8"
   - "1.9"
   - "1.10"
+  - "1.11"
+  - "1.12"
 otp_release:
+  - "20.0"
   - "21.0"
+  - "22.0"
+  - "23.0"
+  - "24.0"
+
+jobs:
+  exclude:
+    - elixir: "1.8"
+      otp_release: "23.0"
+    - elixir: "1.8"
+      otp_release: "24.0"
+    - elixir: "1.9"
+      otp_release: "23.0"
+    - elixir: "1.9"
+      otp_release: "24.0"
+    - elixir: "1.10"
+      otp_release: "20.0"
+    - elixir: "1.10"
+      otp_release: "23.0"
+    - elixir: "1.10"
+      otp_release: "24.0"
+    - elixir: "1.11"
+      otp_release: "20.0"
+    - elixir: "1.11"
+      otp_release: "24.0"
+    - elixir: "1.12"
+      otp_release: "20.0"
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,28 +11,19 @@ otp_release:
   - "21.0"
   - "22.0"
   - "23.0"
-  - "24.0"
 
 jobs:
   exclude:
     - elixir: "1.8"
       otp_release: "23.0"
-    - elixir: "1.8"
-      otp_release: "24.0"
     - elixir: "1.9"
       otp_release: "23.0"
-    - elixir: "1.9"
-      otp_release: "24.0"
     - elixir: "1.10"
       otp_release: "20.0"
     - elixir: "1.10"
       otp_release: "23.0"
-    - elixir: "1.10"
-      otp_release: "24.0"
     - elixir: "1.11"
       otp_release: "20.0"
-    - elixir: "1.11"
-      otp_release: "24.0"
     - elixir: "1.12"
       otp_release: "20.0"
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Dnsimple.Mixfile do
   def project do
     [app: :dnsimple,
      version: "3.0.0",
-     elixir: "~> 1.6",
+     elixir: "~> 1.8",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      package: package(),


### PR DESCRIPTION
As of filing this PR OTP 24 is still in RC state. I'll review this PR in about a month to check OTP 24 GA.

ℹ️  https://hexdocs.pm/elixir/1.12.0-rc.0/compatibility-and-deprecations.html#content