### PR TITLE
Deprecates `Dnsimple.Registrar.get_domain_premium_price`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## main
 
+### Release 3.0.1
+
+- CHANGED: Deprecated `Dnsimple.Registrar.get_domain_premium_price`. 
+
 ## Release 3.0.0
 
 - REMOVED: Deprecated attribute `expires_on` has been rmeoved from `Dnsimple.Domain` (dnsimple/dnsimple-elixir#156)

--- a/lib/dnsimple/registrar.ex
+++ b/lib/dnsimple/registrar.ex
@@ -60,6 +60,7 @@ defmodule Dnsimple.Registrar do
 
   """
   @spec get_domain_premium_price(Client.t, String.t, String.t, map(), keyword()) :: {:ok|:error, Response.t}
+  @deprecated "Use get_domain_prices/4 instead"
   def get_domain_premium_price(client, account_id, domain_name, params \\ %{}, options \\ []) do
     url     = Client.versioned("/#{account_id}/registrar/domains/#{domain_name}/premium_price")
     options = Keyword.put(options, :action, Map.get(params, :action))

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Dnsimple.Mixfile do
 
   def project do
     [app: :dnsimple,
-     version: "3.0.0",
+     version: "3.0.1",
      elixir: "~> 1.8",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,


### PR DESCRIPTION
Deprecates `Dnsimple.Registrar.get_domain_premium_price` in favour of `Dnsimple.Registrar.get_domain_prices`