### PR TITLE
Add support for key-data interface creating delegation signer records

### DIFF
--- a/lib/dnsimple/delegation_signer_record.ex
+++ b/lib/dnsimple/delegation_signer_record.ex
@@ -13,10 +13,11 @@ defmodule Dnsimple.DelegationSignerRecord do
     digest: String.t,
     digest_type: String.t,
     keytag: String.t,
+    public_key: String.t,
     created_at: String.t,
     updated_at: String.t,
   }
 
-  defstruct ~w(id domain_id algorithm digest digest_type keytag created_at updated_at)a
+  defstruct ~w(id domain_id algorithm digest digest_type keytag public_key created_at updated_at)a
 
 end

--- a/lib/dnsimple/tld.ex
+++ b/lib/dnsimple/tld.ex
@@ -16,10 +16,11 @@ defmodule Dnsimple.Tld do
     registration_enabled: boolean,
     renewal_enabled: boolean,
     transfer_enabled: boolean,
+    dnssec_interface_type: String.t,
   }
 
   defstruct ~w(tld tld_type idn whois_privacy auto_renew_only
-               minimum_registration
-               registration_enabled renewal_enabled transfer_enabled)a
+               minimum_registration registration_enabled
+               renewal_enabled transfer_enabled dnssec_interface_type)a
 
 end

--- a/test/dnsimple/tlds_test.exs
+++ b/test/dnsimple/tlds_test.exs
@@ -62,6 +62,7 @@ defmodule Dnsimple.TldsTest do
         assert data.registration_enabled == true
         assert data.renewal_enabled == true
         assert data.transfer_enabled == true
+        assert data.dnssec_interface_type == "ds"
       end
     end
   end

--- a/test/fixtures.http/createDelegationSignerRecord/created.http
+++ b/test/fixtures.http/createDelegationSignerRecord/created.http
@@ -17,4 +17,4 @@ X-Permitted-Cross-Domain-Policies: none
 X-XSS-Protection: 1; mode=block
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":2,"domain_id":1010,"algorithm":"13","digest":"684a1f049d7d082b7f98691657da5a65764913df7f065f6f8c36edf62d66ca03","digest_type":"2","keytag":"2371","created_at":"2017-03-03T15:24:00Z","updated_at":"2017-03-03T15:24:00Z"}}
+{"data":{"id":2,"domain_id":1010,"algorithm":"13","digest":"684a1f049d7d082b7f98691657da5a65764913df7f065f6f8c36edf62d66ca03","digest_type":"2","keytag":"2371","public_key":null,"created_at":"2017-03-03T15:24:00Z","updated_at":"2017-03-03T15:24:00Z"}}

--- a/test/fixtures.http/getDelegationSignerRecord/success.http
+++ b/test/fixtures.http/getDelegationSignerRecord/success.http
@@ -17,4 +17,4 @@ X-Permitted-Cross-Domain-Policies: none
 X-XSS-Protection: 1; mode=block
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":24,"domain_id":1010,"algorithm":"8","digest":"C1F6E04A5A61FBF65BF9DC8294C363CF11C89E802D926BDAB79C55D27BEFA94F","digest_type":"2","keytag":"44620","created_at":"2017-03-03T13:49:58Z","updated_at":"2017-03-03T13:49:58Z"}}
+{"data":{"id":24,"domain_id":1010,"algorithm":"8","digest":"C1F6E04A5A61FBF65BF9DC8294C363CF11C89E802D926BDAB79C55D27BEFA94F","digest_type":"2","keytag":"44620","public_key":null,"created_at":"2017-03-03T13:49:58Z","updated_at":"2017-03-03T13:49:58Z"}}

--- a/test/fixtures.http/getTld/success.http
+++ b/test/fixtures.http/getTld/success.http
@@ -17,4 +17,4 @@ X-Permitted-Cross-Domain-Policies: none
 X-XSS-Protection: 1; mode=block
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"tld":"com","tld_type":1,"whois_privacy":true,"auto_renew_only":false,"idn":true,"minimum_registration":1,"registration_enabled":true,"renewal_enabled":true,"transfer_enabled":true}}
+{"data":{"tld":"com","tld_type":1,"whois_privacy":true,"auto_renew_only":false,"idn":true,"minimum_registration":1,"registration_enabled":true,"renewal_enabled":true,"transfer_enabled":true,"dnssec_interface_type":"ds"}}

--- a/test/fixtures.http/listDelegationSignerRecords/success.http
+++ b/test/fixtures.http/listDelegationSignerRecords/success.http
@@ -17,4 +17,4 @@ X-Permitted-Cross-Domain-Policies: none
 X-XSS-Protection: 1; mode=block
 Strict-Transport-Security: max-age=31536000
 
-{"data":[{"id":24,"domain_id":1010,"algorithm":"8","digest":"C1F6E04A5A61FBF65BF9DC8294C363CF11C89E802D926BDAB79C55D27BEFA94F","digest_type":"2","keytag":"44620","created_at":"2017-03-03T13:49:58Z","updated_at":"2017-03-03T13:49:58Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":1,"total_pages":1}}
+{"data":[{"id":24,"domain_id":1010,"algorithm":"8","digest":"C1F6E04A5A61FBF65BF9DC8294C363CF11C89E802D926BDAB79C55D27BEFA94F","digest_type":"2","keytag":"44620","public_key":null,"created_at":"2017-03-03T13:49:58Z","updated_at":"2017-03-03T13:49:58Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":1,"total_pages":1}}

--- a/test/fixtures.http/listTlds/success.http
+++ b/test/fixtures.http/listTlds/success.http
@@ -17,4 +17,4 @@ X-Permitted-Cross-Domain-Policies: none
 X-XSS-Protection: 1; mode=block
 Strict-Transport-Security: max-age=31536000
 
-{"data":[{"tld":"ac","tld_type":2,"whois_privacy":false,"auto_renew_only":true,"idn":false,"minimum_registration":1,"registration_enabled":true,"renewal_enabled":true,"transfer_enabled":false},{"tld":"academy","tld_type":3,"whois_privacy":true,"auto_renew_only":false,"idn":true,"minimum_registration":1,"registration_enabled":true,"renewal_enabled":true,"transfer_enabled":true}],"pagination":{"current_page":1,"per_page":2,"total_entries":195,"total_pages":98}}
+{"data":[{"tld":"ac","tld_type":2,"whois_privacy":false,"auto_renew_only":true,"idn":false,"minimum_registration":1,"registration_enabled":true,"renewal_enabled":true,"transfer_enabled":false,"dnssec_interface_type":"ds"},{"tld":"academy","tld_type":3,"whois_privacy":true,"auto_renew_only":false,"idn":true,"minimum_registration":1,"registration_enabled":true,"renewal_enabled":true,"transfer_enabled":true,"dnssec_interface_type":"key"}],"pagination":{"current_page":1,"per_page":2,"total_entries":195,"total_pages":98}}


### PR DESCRIPTION
This PR:

- Updates the fixtures from dnsimple-developer repo to reflect the latest changes to our DNSSEC-related APIs.
- Adds new fields to affected structs.

