### PR TITLE
Adds the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,18 @@
+---
+name: release
+
+on:
+  push:
+    tags:
+      - v*.*.*
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - name: Publish to Hex
+        uses: erlangpack/github-actions@v1
+        env:
+          HEX_API_KEY: ${{ secrets.HEX_API_KEY }}


### PR DESCRIPTION
Adds the automated release workflow.

When a new tag is pushed the release workflow will pick it up and start the releasing of the new version.

Things that need to be done (configuration wise), which I have no access to (we need someone with admin rights on this repo for that):

- [x] add the HEX_API_KEY to the secrets