### PR TITLE
Group module docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## main
 
+- CHANGED: Grouped module docs to make them easier to navigate.
+
 ### Release 3.1.0
 
 - CHANGED: Updated DNSSEC-related structs and entry-points to support DS record key-data interface. (dnsimple/dnsimple-elixir#171)

--- a/lib/dnsimple.ex
+++ b/lib/dnsimple.ex
@@ -5,6 +5,8 @@ defmodule Dnsimple do
 
 
   defmodule Error do
+    @moduledoc false
+
     def decode(body) do
       Poison.decode!(body)
     end
@@ -186,6 +188,8 @@ defmodule Dnsimple do
 
 
   defmodule Listing do
+    @moduledoc section: :util
+
     @doc """
     Issues a GET request to the given url processing the listing options first.
     """

--- a/lib/dnsimple/account.ex
+++ b/lib/dnsimple/account.ex
@@ -5,6 +5,7 @@ defmodule Dnsimple.Account do
   See:
   - https://developer.dnsimple.com/v2/accounts/
   """
+  @moduledoc section: :data_types
 
   @type t :: %__MODULE__{
     id: integer,

--- a/lib/dnsimple/accounts.ex
+++ b/lib/dnsimple/accounts.ex
@@ -3,6 +3,7 @@ defmodule Dnsimple.Accounts do
   Provides functions to interact with the
   [account endpoints](https://developer.dnsimple.com/v2/accounts/).
   """
+  @moduledoc section: :api
 
   alias Dnsimple.Client
   alias Dnsimple.Account

--- a/lib/dnsimple/certificate.ex
+++ b/lib/dnsimple/certificate.ex
@@ -12,6 +12,7 @@ defmodule Dnsimple.Certificate do
   - https://developer.dnsimple.com/v2/certificates
   - https://developer.dnsimple.com/v2/certificates/#certificate-attributes
   """
+  @moduledoc section: :data_types
 
   @type t :: %__MODULE__{
     id: integer,

--- a/lib/dnsimple/certificate_purchase.ex
+++ b/lib/dnsimple/certificate_purchase.ex
@@ -2,6 +2,7 @@ defmodule Dnsimple.CertificatePurchase do
   @moduledoc """
   Represents a Certificate Purchase order.
   """
+  @moduledoc section: :data_types
 
   @type t :: %__MODULE__{
     id: integer,

--- a/lib/dnsimple/certificate_renewal.ex
+++ b/lib/dnsimple/certificate_renewal.ex
@@ -2,6 +2,7 @@ defmodule Dnsimple.CertificateRenewal do
   @moduledoc """
   Represents a Certificate Renewal order.
   """
+  @moduledoc section: :data_types
 
   @type t :: %__MODULE__{
     id: integer,

--- a/lib/dnsimple/certificates.ex
+++ b/lib/dnsimple/certificates.ex
@@ -3,6 +3,7 @@ defmodule Dnsimple.Certificates do
   Provides functions to interact with the
   [SSL certificate endpoints](https://developer.dnsimple.com/v2/certificates/).
   """
+  @moduledoc section: :api
 
   alias Dnsimple.Client
   alias Dnsimple.Listing

--- a/lib/dnsimple/collaborator.ex
+++ b/lib/dnsimple/collaborator.ex
@@ -5,6 +5,7 @@ defmodule Dnsimple.Collaborator do
   See:
   - https://developer.dnsimple.com/v2/domains/collaborators
   """
+  @moduledoc section: :data_types
 
   @type t :: %__MODULE__{
     id: integer,

--- a/lib/dnsimple/contact.ex
+++ b/lib/dnsimple/contact.ex
@@ -5,6 +5,7 @@ defmodule Dnsimple.Contact do
   See:
   - https://developer.dnsimple.com/v2/contacts/
   """
+  @moduledoc section: :data_types
 
   @type t :: %__MODULE__{
     id: integer,

--- a/lib/dnsimple/contacts.ex
+++ b/lib/dnsimple/contacts.ex
@@ -3,6 +3,7 @@ defmodule Dnsimple.Contacts do
   Provides functions to interact with the
   [contact endpoints](https://developer.dnsimple.com/v2/contacts/).
   """
+  @moduledoc section: :api
 
   alias Dnsimple.Client
   alias Dnsimple.Listing

--- a/lib/dnsimple/delegation_signer_record.ex
+++ b/lib/dnsimple/delegation_signer_record.ex
@@ -5,6 +5,7 @@ defmodule Dnsimple.DelegationSignerRecord do
   See:
   - https://developer.dnsimple.com/v2/domains/dnssec/
   """
+  @moduledoc section: :data_types
 
   @type t :: %__MODULE__{
     id: integer,

--- a/lib/dnsimple/dnssec.ex
+++ b/lib/dnsimple/dnssec.ex
@@ -5,6 +5,7 @@ defmodule Dnsimple.Dnssec do
   See:
   - https://developer.dnsimple.com/v2/domains/dnssec/
   """
+  @moduledoc section: :data_types
 
   @type t :: %__MODULE__{
     id: integer,

--- a/lib/dnsimple/domain.ex
+++ b/lib/dnsimple/domain.ex
@@ -6,6 +6,7 @@ defmodule Dnsimple.Domain do
   - https://developer.dnsimple.com/v2/domains/
   - https://developer.dnsimple.com/v2/domains/#domain-attributes
   """
+  @moduledoc section: :data_types
 
   @type t :: %__MODULE__{
     id: integer,

--- a/lib/dnsimple/domain_check.ex
+++ b/lib/dnsimple/domain_check.ex
@@ -1,10 +1,11 @@
 defmodule Dnsimple.DomainCheck do
   @moduledoc """
-  Represent a domain check.
+  Represents a domain check.
 
   See:
   - https://developer.dnsimple.com/v2/registrar/#check
   """
+  @moduledoc section: :data_types
 
   @type t :: %__MODULE__{
     domain: String.t,

--- a/lib/dnsimple/domain_premium_price.ex
+++ b/lib/dnsimple/domain_premium_price.ex
@@ -5,6 +5,7 @@ defmodule Dnsimple.DomainPremiumPrice do
   See:
   - https://developer.dnsimple.com/v2/registrar/#premium-price
   """
+  @moduledoc section: :data_types
 
   @type t :: %__MODULE__{
     premium_price: String.t,

--- a/lib/dnsimple/domain_price.ex
+++ b/lib/dnsimple/domain_price.ex
@@ -5,6 +5,7 @@ defmodule Dnsimple.DomainPrice do
   See:
   - https://developer.dnsimple.com/v2/registrar/#getDomainPrices
   """
+  @moduledoc section: :data_types
 
   @type t :: %__MODULE__{
     domain: String.t,

--- a/lib/dnsimple/domain_registration.ex
+++ b/lib/dnsimple/domain_registration.ex
@@ -5,6 +5,7 @@ defmodule Dnsimple.DomainRegistration do
   See:
   - https://developer.dnsimple.com/v2/registrar/#register
   """
+  @moduledoc section: :data_types
 
   @type t :: %__MODULE__{
     id: integer,

--- a/lib/dnsimple/domain_renewal.ex
+++ b/lib/dnsimple/domain_renewal.ex
@@ -5,6 +5,7 @@ defmodule Dnsimple.DomainRenewal do
   See:
   - https://developer.dnsimple.com/v2/registrar/#renew
   """
+  @moduledoc section: :data_types
 
   @type t :: %__MODULE__{
     id: integer,

--- a/lib/dnsimple/domain_transfer.ex
+++ b/lib/dnsimple/domain_transfer.ex
@@ -5,6 +5,8 @@ defmodule Dnsimple.DomainTransfer do
   See:
   - https://developer.dnsimple.com/v2/registrar/#transfer
   """
+  @moduledoc section: :data_types
+
   @type t :: %__MODULE__{
     id: integer,
     domain_id: integer,

--- a/lib/dnsimple/domains.ex
+++ b/lib/dnsimple/domains.ex
@@ -3,6 +3,7 @@ defmodule Dnsimple.Domains do
   Provides functions to interact with the
   [domain endpoints](https://developer.dnsimple.com/v2/domains/).
   """
+  @moduledoc section: :api
 
   alias Dnsimple.Client
   alias Dnsimple.Listing

--- a/lib/dnsimple/email_forward.ex
+++ b/lib/dnsimple/email_forward.ex
@@ -5,6 +5,7 @@ defmodule Dnsimple.EmailForward do
   See:
   - https://developer.dnsimple.com/v2/domains/email-forwards/
   """
+  @moduledoc section: :data_types
 
   @type t :: %__MODULE__{
     id: integer,

--- a/lib/dnsimple/identity.ex
+++ b/lib/dnsimple/identity.ex
@@ -6,6 +6,7 @@ defmodule Dnsimple.Identity do
   See:
   - https://developer.dnsimple.com/v2/identity/
   """
+  @moduledoc section: :api
 
   alias Dnsimple.Client
   alias Dnsimple.Response

--- a/lib/dnsimple/oauth.ex
+++ b/lib/dnsimple/oauth.ex
@@ -7,6 +7,7 @@ defmodule Dnsimple.Oauth do
   - https://developer.dnsimple.com/v2/oauth/
   - https://developer.dnsimple.com/v2/#authentication
   """
+  @moduledoc section: :api
 
   alias Dnsimple.Client
   alias Dnsimple.Response

--- a/lib/dnsimple/oauth_token.ex
+++ b/lib/dnsimple/oauth_token.ex
@@ -6,6 +6,7 @@ defmodule Dnsimple.OauthToken do
   - https://developer.dnsimple.com/v2/oauth/
   - https://developer.dnsimple.com/v2/oauth/#step-2---access-token
   """
+  @moduledoc section: :data_types
 
   @type t :: %__MODULE__{
     access_token: String.t,

--- a/lib/dnsimple/push.ex
+++ b/lib/dnsimple/push.ex
@@ -5,6 +5,7 @@ defmodule Dnsimple.Push do
   See:
   - https://developer.dnsimple.com/v2/domains/pushes/
   """
+  @moduledoc section: :data_types
 
   @type t :: %__MODULE__{
     id: integer,

--- a/lib/dnsimple/registrar.ex
+++ b/lib/dnsimple/registrar.ex
@@ -9,6 +9,7 @@ defmodule Dnsimple.Registrar do
   - https://developer.dnsimple.com/v2/registrar/whois-privacy/
   - https://developer.dnsimple.com/v2/registrar/delegation/
   """
+  @moduledoc section: :api
 
   alias Dnsimple.Client
   alias Dnsimple.Response

--- a/lib/dnsimple/response.ex
+++ b/lib/dnsimple/response.ex
@@ -1,4 +1,6 @@
 defmodule Dnsimple.Response do
+  @moduledoc section: :util
+
   defstruct ~w(http_response data pagination rate_limit rate_limit_remaining rate_limit_reset)a
 
   @type t :: %__MODULE__{
@@ -11,6 +13,8 @@ defmodule Dnsimple.Response do
   }
 
   defmodule Pagination do
+    @moduledoc section: :util
+
     defstruct ~w(current_page per_page total_pages total_entries)a
 
     @type t :: %__MODULE__{

--- a/lib/dnsimple/service.ex
+++ b/lib/dnsimple/service.ex
@@ -5,6 +5,7 @@ defmodule Dnsimple.Service do
   See:
   - https://developer.dnsimple.com/v2/services
   """
+  @moduledoc section: :data_types
 
   defmodule Setting do
     @moduledoc """
@@ -13,6 +14,7 @@ defmodule Dnsimple.Service do
     See:
     - https://developer.dnsimple.com/v2/services
     """
+    @moduledoc section: :data_types
 
     @type t :: %__MODULE__{
       name: String.t,

--- a/lib/dnsimple/services.ex
+++ b/lib/dnsimple/services.ex
@@ -7,6 +7,7 @@ defmodule Dnsimple.Services do
   - https://developer.dnsimple.com/v2/services
   - https://developer.dnsimple.com/v2/services/domains/
   """
+  @moduledoc section: :api
 
   alias Dnsimple.Client
   alias Dnsimple.Listing

--- a/lib/dnsimple/template.ex
+++ b/lib/dnsimple/template.ex
@@ -5,6 +5,7 @@ defmodule Dnsimple.Template do
   See:
   - https://developer.dnsimple.com/v2/templates/
   """
+  @moduledoc section: :data_types
 
   @type t :: %__MODULE__{
     id: integer,

--- a/lib/dnsimple/template_record.ex
+++ b/lib/dnsimple/template_record.ex
@@ -5,6 +5,7 @@ defmodule Dnsimple.TemplateRecord do
   See:
   - https://developer.dnsimple.com/v2/templates/records/
   """
+  @moduledoc section: :data_types
 
   @type t :: %__MODULE__{
     id: integer,

--- a/lib/dnsimple/templates.ex
+++ b/lib/dnsimple/templates.ex
@@ -8,6 +8,7 @@ defmodule Dnsimple.Templates do
   - https://developer.dnsimple.com/v2/templates/records/
   - https://developer.dnsimple.com/v2/templates/domains/
   """
+  @moduledoc section: :api
 
   alias Dnsimple.Client
   alias Dnsimple.Listing

--- a/lib/dnsimple/tld.ex
+++ b/lib/dnsimple/tld.ex
@@ -5,6 +5,7 @@ defmodule Dnsimple.Tld do
   See: https://developer.dnsimple.com/v2/tlds
   See: https://developer.dnsimple.com/v2/tlds/#tld-attributes
   """
+  @moduledoc section: :data_types
 
   @type t :: %__MODULE__{
     tld: String.t,

--- a/lib/dnsimple/tld_extended_attribute.ex
+++ b/lib/dnsimple/tld_extended_attribute.ex
@@ -5,6 +5,7 @@ defmodule Dnsimple.TldExtendedAttribute do
   See:
   - https://developer.dnsimple.com/v2/tlds/#extended-attributes
   """
+  @moduledoc section: :data_types
 
   defmodule Option do
     @moduledoc """
@@ -13,6 +14,7 @@ defmodule Dnsimple.TldExtendedAttribute do
     See:
     - https://developer.dnsimple.com/v2/tlds/#extended-attributes
     """
+    @moduledoc section: :data_types
 
     @type t :: %__MODULE__{
       title: String.t,

--- a/lib/dnsimple/tlds.ex
+++ b/lib/dnsimple/tlds.ex
@@ -6,6 +6,7 @@ defmodule Dnsimple.Tlds do
   See:
   - https://developer.dnsimple.com/v2/tlds/
   """
+  @moduledoc section: :api
 
   alias Dnsimple.Client
   alias Dnsimple.Listing

--- a/lib/dnsimple/user.ex
+++ b/lib/dnsimple/user.ex
@@ -5,6 +5,7 @@ defmodule Dnsimple.User do
   See:
   - https://developer.dnsimple.com/v2/identity/
   """
+  @moduledoc section: :data_types
 
   @type t :: %__MODULE__{
     id: integer,

--- a/lib/dnsimple/vanity_name_server.ex
+++ b/lib/dnsimple/vanity_name_server.ex
@@ -5,6 +5,7 @@ defmodule Dnsimple.VanityNameServer do
   See:
   - https://developer.dnsimple.com/v2/vanity/
   """
+  @moduledoc section: :data_types
 
   @type t :: %__MODULE__{
     id: integer,

--- a/lib/dnsimple/vanity_name_servers.ex
+++ b/lib/dnsimple/vanity_name_servers.ex
@@ -6,6 +6,7 @@ defmodule Dnsimple.VanityNameServers do
   See:
   - https://developer.dnsimple.com/v2/vanity/
   """
+  @moduledoc section: :api
 
   alias Dnsimple.Client
   alias Dnsimple.Response

--- a/lib/dnsimple/webhook.ex
+++ b/lib/dnsimple/webhook.ex
@@ -5,6 +5,7 @@ defmodule Dnsimple.Webhook do
   See:
   - https://developer.dnsimple.com/v2/webhooks
   """
+  @moduledoc section: :data_types
 
   @type t :: %__MODULE__{
     id: integer,

--- a/lib/dnsimple/webhooks.ex
+++ b/lib/dnsimple/webhooks.ex
@@ -6,6 +6,7 @@ defmodule Dnsimple.Webhooks do
   See:
   - https://developer.dnsimple.com/v2/webhooks/
   """
+  @moduledoc section: :api
 
   alias Dnsimple.Client
   alias Dnsimple.Listing

--- a/lib/dnsimple/whoami.ex
+++ b/lib/dnsimple/whoami.ex
@@ -5,6 +5,7 @@ defmodule Dnsimple.Whoami do
   See:
   - https://developer.dnsimple.com/v2/identity/
   """
+  @moduledoc section: :data_types
 
   @type t :: %__MODULE__{
     user: Dnsimple.User.t,

--- a/lib/dnsimple/whois_privacy.ex
+++ b/lib/dnsimple/whois_privacy.ex
@@ -5,6 +5,7 @@ defmodule Dnsimple.WhoisPrivacy do
   See:
   - https://developer.dnsimple.com/v2/registrar/whois-privacy/
   """
+  @moduledoc section: :data_types
 
   @type t :: %__MODULE__{
     id: integer,

--- a/lib/dnsimple/whois_privacy_renewal.ex
+++ b/lib/dnsimple/whois_privacy_renewal.ex
@@ -5,6 +5,7 @@ defmodule Dnsimple.WhoisPrivacyRenewal do
   See:
   - https://developer.dnsimple.com/v2/registrar/whois-privacy/
   """
+  @moduledoc section: :data_types
 
   @type t :: %__MODULE__{
     id: integer,

--- a/lib/dnsimple/zone.ex
+++ b/lib/dnsimple/zone.ex
@@ -5,6 +5,7 @@ defmodule Dnsimple.Zone do
   See:
   - https://developer.dnsimple.com/v2/zones/
   """
+  @moduledoc section: :data_types
 
   @type t :: %__MODULE__{
     id: integer,
@@ -25,6 +26,7 @@ defmodule Dnsimple.Zone do
     - https://developer.dnsimple.com/v2/zones/#file
     - https://support.dnsimple.com/articles/zone-files/#whats-a-zone-file
     """
+    @moduledoc section: :data_types
 
     @type t :: %__MODULE__{
       zone: String.t,

--- a/lib/dnsimple/zone_distribution.ex
+++ b/lib/dnsimple/zone_distribution.ex
@@ -6,6 +6,7 @@ defmodule Dnsimple.ZoneDistribution do
   - https://developer.dnsimple.com/v2/zones
   - https://developer.dnsimple.com/v2/zones/#checkZoneDistribution
   """
+  @moduledoc section: :data_types
 
   @type t :: %__MODULE__{
     distributed: boolean,

--- a/lib/dnsimple/zone_record.ex
+++ b/lib/dnsimple/zone_record.ex
@@ -6,6 +6,7 @@ defmodule Dnsimple.ZoneRecord do
   - https://developer.dnsimple.com/v2/zones/records
   - https://developer.dnsimple.com/v2/zones/records/#zone-record-regions
   """
+  @moduledoc section: :data_types
 
   @type t :: %__MODULE__{
     id: integer,

--- a/lib/dnsimple/zones.ex
+++ b/lib/dnsimple/zones.ex
@@ -7,6 +7,7 @@ defmodule Dnsimple.Zones do
   - https://developer.dnsimple.com/v2/zones/
   - https://developer.dnsimple.com/v2/zones/records/
   """
+  @moduledoc section: :api
 
   alias Dnsimple.Client
   alias Dnsimple.Listing

--- a/mix.exs
+++ b/mix.exs
@@ -52,6 +52,11 @@ defmodule Dnsimple.Mixfile do
         "LICENSE.md": [title: "License"],
         "README.md": [title: "Overview"],
       ],
+      groups_for_modules: [
+        "API": & &1[:section] == :api,
+        "Data Types": & &1[:section] == :data_types,
+        "Util": & &1[:section] == :util
+      ],
       main: "readme",
       source_url: @source_url,
       source_ref: "v#{@version}",


### PR DESCRIPTION
I checked out the docs and it took quite a while to find what I was looking for. Maybe it's just unfamiliarity with Elixir conventions (e.g. plural-named modules have functions, singular-named modules are data types). I grouped the modules in a way that I think would make them more immediate to someone wanting to use this library. I picked "API", "Data Types", and "Util" as the group names - I'm certainly open to different groupings or names, but this made sense to me.

## Before

![image](https://user-images.githubusercontent.com/1111/146111356-27410fc3-a682-4806-b682-813dd410a312.png)

## After

![image](https://user-images.githubusercontent.com/1111/146111302-49c55be2-860b-4f4a-b7fb-0ff830fb8250.png)
