### PR TITLE
No longer require `contact_id` to purchase LetsEncrypt certificates

### DIFF
--- a/lib/dnsimple/certificates.ex
+++ b/lib/dnsimple/certificates.ex
@@ -111,20 +111,20 @@ defmodule Dnsimple.Certificates do
 
       # Purchase a certificate for a single name
       client = %Dnsimple.Client{access_token: "a1b2c3d4"}
-      {:ok, response} = Dnsimple.Certificates.purchase_letsencrypt_certificate(client, account_id = "1010", domain_id = "example.com", contact_id: 1, name: "www")
+      {:ok, response} = Dnsimple.Certificates.purchase_letsencrypt_certificate(client, account_id = "1010", domain_id = "example.com", name: "www")
       purchase_id     = response.data.id
 
       # Purchase a certificate for multiple names (SAN)
       client = %Dnsimple.Client{access_token: "a1b2c3d4"}
-      {:ok, response} = Dnsimple.Certificates.purchase_letsencrypt_certificate(client, account_id = "1010", domain_id = "example.com", contact_id: 1, alternate_names: ["example.com", "www.example.com", "status.example.com"])
+      {:ok, response} = Dnsimple.Certificates.purchase_letsencrypt_certificate(client, account_id = "1010", domain_id = "example.com", alternate_names: ["example.com", "www.example.com", "status.example.com"])
 
       # Enable auto-renew on purchase
       client = %Dnsimple.Client{access_token: "a1b2c3d4"}
-      {:ok, response} = Dnsimple.Certificates.purchase_letsencrypt_certificate(client, account_id = "1010", domain_id = "example.com", contact_id: 1, auto_renew: true)
+      {:ok, response} = Dnsimple.Certificates.purchase_letsencrypt_certificate(client, account_id = "1010", domain_id = "example.com", auto_renew: true)
 
   """
   @spec purchase_letsencrypt_certificate(Client.t, String.t | integer, String.t | integer, Keyword.t, Keyword.t) :: {:ok|:error, Response.t}
-  def purchase_letsencrypt_certificate(client, account_id, domain_id, attributes, options \\ []) do
+  def purchase_letsencrypt_certificate(client, account_id, domain_id, attributes \\ %{}, options \\ []) do
     url = Client.versioned("/#{account_id}/domains/#{domain_id}/certificates/letsencrypt")
 
     Client.post(client, url, attributes, options)

--- a/test/dnsimple/certificates_test.exs
+++ b/test/dnsimple/certificates_test.exs
@@ -111,13 +111,11 @@ defmodule Dnsimple.CertificatesTest do
       url     = "#{@client.base_url}/v2/#{@account_id}/domains/bingo.pizza/certificates/letsencrypt"
       method  = "post"
       fixture = "purchaseLetsencryptCertificate/success.http"
-      attributes = %{
-        contact_id: 1010
-      }
+      attributes = %{}
       {:ok, body} = Poison.encode(attributes)
 
       use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url, request_body: body) do
-        {:ok, response} = @module.purchase_letsencrypt_certificate(@client, @account_id, "bingo.pizza", attributes)
+        {:ok, response} = @module.purchase_letsencrypt_certificate(@client, @account_id, "bingo.pizza")
         assert response.__struct__ == Dnsimple.Response
 
         data = response.data


### PR DESCRIPTION
We no longer require a contact_id to be provided to be able to purchase a Lets Encrypt certificate.