### PR TITLE
Expose all information available in error responses

### DIFF
--- a/lib/dnsimple.ex
+++ b/lib/dnsimple.ex
@@ -18,12 +18,12 @@ defmodule Dnsimple do
     invalid request information.
     """
 
-    defexception [:message, :errors, :http_response]
+    defexception [:message, :attribute_errors, :http_response]
 
     def new(http_response) do
       %__MODULE__{
         message: extract_message(http_response),
-        errors: extract_errors(http_response),
+        attribute_errors: extract_attribute_errors(http_response),
         http_response: http_response
       }
     end
@@ -37,7 +37,7 @@ defmodule Dnsimple do
       end
     end
 
-    defp extract_errors(http_response) do
+    defp extract_attribute_errors(http_response) do
       if is_json_response?(http_response) do
         Error.decode(http_response.body) |> Map.get("errors")
       end

--- a/lib/dnsimple.ex
+++ b/lib/dnsimple.ex
@@ -18,11 +18,12 @@ defmodule Dnsimple do
     invalid request information.
     """
 
-    defexception [:message, :http_response]
+    defexception [:message, :errors, :http_response]
 
     def new(http_response) do
       %__MODULE__{
         message: extract_message(http_response),
+        errors: extract_errors(http_response),
         http_response: http_response
       }
     end
@@ -33,6 +34,12 @@ defmodule Dnsimple do
         "HTTP #{http_response.status_code}: #{message}"
       else
         "HTTP #{http_response.status_code}: #{http_response.body}"
+      end
+    end
+
+    defp extract_errors(http_response) do
+      if is_json_response?(http_response) do
+        Error.decode(http_response.body) |> Map.get("errors")
       end
     end
 

--- a/lib/dnsimple.ex
+++ b/lib/dnsimple.ex
@@ -21,12 +21,25 @@ defmodule Dnsimple do
     defexception [:message, :http_response]
 
     def new(http_response) do
-      message = Error.decode(http_response.body) |> Map.get("message")
-
       %__MODULE__{
-        message: "HTTP #{http_response.status_code}: #{message}",
+        message: extract_message(http_response),
         http_response: http_response
       }
+    end
+
+    defp extract_message(http_response) do
+      if is_json_response?(http_response) do
+        message = Error.decode(http_response.body) |> Map.get("message")
+        "HTTP #{http_response.status_code}: #{message}"
+      else
+        "HTTP #{http_response.status_code}: #{http_response.body}"
+      end
+    end
+
+    defp is_json_response?(http_response) do
+      Enum.any?(http_response.headers, fn({header, content}) ->
+        header == "Content-Type" && String.starts_with?(content, "application/json")
+      end)
     end
   end
 

--- a/test/dnsimple_test.exs
+++ b/test/dnsimple_test.exs
@@ -19,20 +19,21 @@ defmodule Dnsimple.ClientTest do
   describe ".execute" do
     setup do
       client  = %Dnsimple.Client{access_token: "i-am-a-token", base_url: "https://api.dnsimple.test"}
-      url     = "#{client.base_url}/v2/1010/domains"
-      fixture = ExvcrUtils.response_fixture("listDomains/success.http", method: "get", url: url)
-
-      {:ok, client: client, fixture: fixture}
+      {:ok, client: client}
     end
 
-    test "handles headers defines as a map", %{client: client, fixture: fixture} do
+    test "handles headers defines as a map", %{client: client} do
+      url     = "#{client.base_url}/v2/1010/domains"
+      fixture = ExvcrUtils.response_fixture("listDomains/success.http", method: "get", url: url)
       use_cassette :stub, fixture  do
         {:ok, response} = Dnsimple.Domains.list_domains(client, "1010", headers: %{page: 2})
         assert response.__struct__ == Dnsimple.Response
       end
     end
 
-    test "handles headers defines as a list", %{client: client, fixture: fixture} do
+    test "handles headers defines as a list", %{client: client} do
+      url     = "#{client.base_url}/v2/1010/domains"
+      fixture = ExvcrUtils.response_fixture("listDomains/success.http", method: "get", url: url)
       use_cassette :stub, fixture  do
         {:ok, response} = Dnsimple.Domains.list_domains(client, "1010", headers: [{"X-Header", "X-Value"}])
         assert response.__struct__ == Dnsimple.Response

--- a/test/dnsimple_test.exs
+++ b/test/dnsimple_test.exs
@@ -59,7 +59,7 @@ defmodule Dnsimple.ClientTest do
         {:error, response} = Dnsimple.Registrar.renew_whois_privacy(client, "1010", domain_id)
         assert response.__struct__ == Dnsimple.RequestError
         assert response.message == "HTTP 400: The whois privacy for example.com has just been renewed, a new renewal cannot be started at this time"
-        assert response.errors == nil
+        assert response.attribute_errors == nil
       end
     end
 
@@ -71,7 +71,7 @@ defmodule Dnsimple.ClientTest do
         {:error, response} = Dnsimple.Contacts.create_contact(client, "1010", attributes)
         assert response.__struct__ == Dnsimple.RequestError
         assert response.message == "HTTP 400: Validation failed"
-        assert response.errors == %{
+        assert response.attribute_errors == %{
           "address1" => ["can't be blank"],
           "city" => ["can't be blank"],
           "country" => ["can't be blank"],
@@ -92,7 +92,7 @@ defmodule Dnsimple.ClientTest do
         {:error, response} = Dnsimple.Domains.list_domains(client, "1010")
         assert response.__struct__ == Dnsimple.RequestError
         assert response.message == "HTTP 502: <html>\n<head><title>502 Bad Gateway</title></head>\n<body bgcolor=\"white\">\n<center><h1>502 Bad Gateway</h1></center>\n<hr><center>nginx</center>\n</body>\n</html>\n"
-        assert response.errors == nil
+        assert response.attribute_errors == nil
       end
     end
   end

--- a/test/dnsimple_test.exs
+++ b/test/dnsimple_test.exs
@@ -59,6 +59,7 @@ defmodule Dnsimple.ClientTest do
         {:error, response} = Dnsimple.Registrar.renew_whois_privacy(client, "1010", domain_id)
         assert response.__struct__ == Dnsimple.RequestError
         assert response.message == "HTTP 400: The whois privacy for example.com has just been renewed, a new renewal cannot be started at this time"
+        assert response.errors == nil
       end
     end
 
@@ -70,6 +71,17 @@ defmodule Dnsimple.ClientTest do
         {:error, response} = Dnsimple.Contacts.create_contact(client, "1010", attributes)
         assert response.__struct__ == Dnsimple.RequestError
         assert response.message == "HTTP 400: Validation failed"
+        assert response.errors == %{
+          "address1" => ["can't be blank"],
+          "city" => ["can't be blank"],
+          "country" => ["can't be blank"],
+          "email" => ["can't be blank", "is an invalid email address"],
+          "first_name" => ["can't be blank"],
+          "last_name" => ["can't be blank"],
+          "phone" => ["can't be blank", "is probably not a phone number"],
+          "postal_code" => ["can't be blank"],
+          "state_province" => ["can't be blank"]
+        }
       end
     end
 
@@ -80,6 +92,7 @@ defmodule Dnsimple.ClientTest do
         {:error, response} = Dnsimple.Domains.list_domains(client, "1010")
         assert response.__struct__ == Dnsimple.RequestError
         assert response.message == "HTTP 502: <html>\n<head><title>502 Bad Gateway</title></head>\n<body bgcolor=\"white\">\n<center><h1>502 Bad Gateway</h1></center>\n<hr><center>nginx</center>\n</body>\n</html>\n"
+        assert response.errors == nil
       end
     end
   end

--- a/test/dnsimple_test.exs
+++ b/test/dnsimple_test.exs
@@ -73,6 +73,15 @@ defmodule Dnsimple.ClientTest do
       end
     end
 
+    test "returns a ResponseError when the response has a 5XX status code", %{client: client} do
+      url        = "#{client.base_url}/v2/1010/domains"
+      fixture    = ExvcrUtils.response_fixture("badgateway.http", method: "get", url: url)
+      use_cassette :stub, fixture  do
+        {:error, response} = Dnsimple.Domains.list_domains(client, "1010")
+        assert response.__struct__ == Dnsimple.RequestError
+        assert response.message == "HTTP 502: <html>\n<head><title>502 Bad Gateway</title></head>\n<body bgcolor=\"white\">\n<center><h1>502 Bad Gateway</h1></center>\n<hr><center>nginx</center>\n</body>\n</html>\n"
+      end
+    end
   end
 
 end


### PR DESCRIPTION
Our error responses sometimes include an errors entry with details about errors on the attributes of the specific resource. We handle those errors via `RequestError`, but we are only considering the message.

This PR:
- Adds an `errors` attribute to `Dnsimple.ResponseError`exception.
- Makes sure that we correctly parse the error responses to provide the value for `errors`.
- Adds missing specs around error response handling.
- Fixes a bug where the client would crash trying to parse non json-encoded error responses.