### PR TITLE
Implement getDomainRenewal and getDomainRegistration endpoints

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
 # Update also: .ci.yml
 elixir 1.11.4-otp-23
+erlang 23.3.4.18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## main
 
+- NEW: Added `Dnsimple.Registrar.get_domain_registration/5` to retrieve a domain registration. (dnsimple/dnsimple-elixir#216)
+- NEW: Added `Dnsimple.Registrar.get_domain_renewal/5` to retrieve a domain renewal. (dnsimple/dnsimple-elixir#216)
+
 ### Release 3.2.1
 
 - CHANGED: Expose all information available in error responses (dnsimple/dnsimple-elixir#197)

--- a/lib/dnsimple/registrar.ex
+++ b/lib/dnsimple/registrar.ex
@@ -113,6 +113,26 @@ defmodule Dnsimple.Registrar do
     |> Response.parse(%{"data" => %DomainRegistration{}})
   end
 
+  @doc """
+  Retrieve the details of an existing domain registration.
+
+  See:
+  - https://developer.dnsimple.com/v2/registrar/#getDomainRegistration
+
+  ## Examples:
+
+      client = %Dnsimple.Client{access_token: "a1b2c3d4"}
+      {:ok, response} = Dnsimple.Registrar.get_domain_registration(client, account_id = 1010, domain_id = "example.com", registration_id = 1)
+
+  """
+  @spec get_domain_registration(Client.t, String.t | integer, String.t, String.t | integer, Keyword.t) :: {:ok|:error, Response.t}
+  def get_domain_registration(client, account_id, domain_name, registration_id, options \\ []) do
+    url = Client.versioned("/#{account_id}/registrar/domains/#{domain_name}/registrations/#{registration_id}")
+
+    Client.get(client, url, options)
+    |> Response.parse(%{"data" => %DomainRegistration{}})
+  end
+
 
   @doc """
   Renews a domain.

--- a/lib/dnsimple/registrar.ex
+++ b/lib/dnsimple/registrar.ex
@@ -155,6 +155,26 @@ defmodule Dnsimple.Registrar do
     |> Response.parse(%{"data" => %DomainRenewal{}})
   end
 
+  @doc """
+  Retrieve the details of an existing domain renewal.
+
+  See:
+  - https://developer.dnsimple.com/v2/registrar/#getDomainRenewal
+
+  ## Examples:
+
+      client = %Dnsimple.Client{access_token: "a1b2c3d4"}
+      {:ok, response} = Dnsimple.Registrar.get_domain_renewal(client, account_id = 1010, domain_id = "example.com", renewal_id = 1)
+
+  """
+  @spec get_domain_renewal(Client.t, String.t | integer, String.t, String.t | integer, Keyword.t) :: {:ok|:error, Response.t}
+  def get_domain_renewal(client, account_id, domain_name, renewal_id, options \\ []) do
+    url = Client.versioned("/#{account_id}/registrar/domains/#{domain_name}/renewals/#{renewal_id}")
+
+    Client.get(client, url, options)
+    |> Response.parse(%{"data" => %DomainRenewal{}})
+  end
+
 
   @doc """
   Starts the transfer of a domain to DNSimple.

--- a/test/dnsimple/registrar_test.exs
+++ b/test/dnsimple/registrar_test.exs
@@ -165,6 +165,28 @@ defmodule Dnsimple.RegistrarTest do
       end
     end
   end
+  
+  describe ".get_domain_renewal" do
+    test "returns the domain renewal in a Dnsimple.Response" do
+      url         = "#{@client.base_url}/v2/#{@account_id}/registrar/domains/example.com/renewals/1"
+      method      = "get"
+      fixture     = "getDomainRenewal/success.http"
+
+      use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url) do
+        {:ok, response} = @module.get_domain_renewal(@client, @account_id, "example.com", 1)
+        assert response.__struct__ == Dnsimple.Response
+
+        data = response.data
+        assert data.__struct__ == Dnsimple.DomainRenewal
+        assert data.id == 1
+        assert data.domain_id == 999
+        assert data.period == 1
+        assert data.state == "renewed"
+        assert data.created_at == "2016-12-09T19:46:45Z"
+        assert data.updated_at == "2016-12-12T19:46:45Z"
+      end
+    end
+  end
 
 
   describe ".transfer_domain" do

--- a/test/dnsimple/registrar_test.exs
+++ b/test/dnsimple/registrar_test.exs
@@ -116,6 +116,31 @@ defmodule Dnsimple.RegistrarTest do
     end
   end
 
+  describe ".get_domain_registration" do
+    test "returns the domain registration in a Dnsimple.Response" do
+      url         = "#{@client.base_url}/v2/#{@account_id}/registrar/domains/example.com/registrations/1"
+      method      = "get"
+      fixture     = "getDomainRegistration/success.http"
+
+      use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url) do
+        {:ok, response} = @module.get_domain_registration(@client, @account_id, "example.com", 1)
+        assert response.__struct__ == Dnsimple.Response
+
+        data = response.data
+        assert data.__struct__ == Dnsimple.DomainRegistration
+        assert data.id == 361
+        assert data.domain_id == 104040
+        assert data.registrant_id == 2715
+        assert data.period == 1
+        assert data.state == "registering"
+        assert data.auto_renew == false
+        assert data.whois_privacy == false
+        assert data.created_at == "2023-01-27T17:44:32Z"
+        assert data.updated_at == "2023-01-27T17:44:40Z"
+      end
+    end
+  end
+
 
   describe ".renew_domain" do
     test "returns the renewed domain in a Dnsimple.Response" do

--- a/test/fixtures.http/getDomainRegistration/success.http
+++ b/test/fixtures.http/getDomainRegistration/success.http
@@ -1,0 +1,20 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Fri, 05 Jun 2020 18:23:53 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2392
+X-RateLimit-Reset: 1591384034
+ETag: W/"80c5827934c13b1ca87a587d96e7d1e8"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 9f4959ee-06a9-488c-906e-27a570cafbbf
+X-Runtime: 0.078429
+X-Frame-Options: DENY
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+Strict-Transport-Security: max-age=31536000
+
+{"data":{"id":361,"domain_id":104040,"registrant_id":2715,"period":1,"state":"registering","auto_renew":false,"whois_privacy":false,"created_at":"2023-01-27T17:44:32Z","updated_at":"2023-01-27T17:44:40Z"}}

--- a/test/fixtures.http/getDomainRenewal/success.http
+++ b/test/fixtures.http/getDomainRenewal/success.http
@@ -1,0 +1,20 @@
+HTTP/1.1 201 Created
+Server: nginx
+Date: Fri, 09 Dec 2016 19:46:57 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2394
+X-RateLimit-Reset: 1481315245
+ETag: W/"179d85ea8a26a3d5dc76e42de2d7918e"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: ba6f2707-5df0-4ffa-b91b-51d4460bab8e
+X-Runtime: 13.571302
+X-Content-Type-Options: nosniff
+X-Download-Options: noopen
+X-Frame-Options: DENY
+X-Permitted-Cross-Domain-Policies: none
+X-XSS-Protection: 1; mode=block
+Strict-Transport-Security: max-age=31536000
+
+{"data":{"id":1,"domain_id":999,"period":1,"state":"renewed","created_at":"2016-12-09T19:46:45Z","updated_at":"2016-12-12T19:46:45Z"}}


### PR DESCRIPTION
Recently we introduced two new endpoints (https://github.com/dnsimple/dnsimple-developer/pull/457) in our API for users to retrieve their domain registration and renewal service objects.

Belongs to https://github.com/dnsimple/dnsimple-business/issues/1674