### PR TITLE
Specify runner OS for CI to ubuntu-20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
 
   test:
     needs: [markdownlint-cli, yamllint]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Elixir ${{matrix.elixir}} / OTP ${{matrix.otp}}
     strategy:
       matrix:


### PR DESCRIPTION
As we use the `ubuntu-latest` tag to select the runner os it now points to `ubuntu-22.04` which has incompatibilities with Erlang/OTP 20-25.