### PR TITLE
Client initialization from Application env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ENHANCEMENTS:
 
 - Added `Dnsimple.Client.new_from_env` to initialize a client from the Application environment. (dnsimple/dnsimple-elixir#219)
+- Deprecate `Dnsimple.Zone.File` use instead `Dnsimple.ZoneFile`. (dnsimple/dnsimple-elixir#219)
 
 ## Release 3.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## main
 
+## 3.4.0 (Unreleased)
+
+ENHANCEMENTS:
+
+- Added `Dnsimple.Client.new_from_env` to initialize a client from the Application environment. (dnsimple/dnsimple-elixir#219)
+
 ## Release 3.3.0
 
 - NEW: Added `Dnsimple.Registrar.get_domain_registration/5` to retrieve a domain registration. (dnsimple/dnsimple-elixir#216)

--- a/README.md
+++ b/README.md
@@ -92,9 +92,11 @@ You can configure DNSimple inside of your app's `config.exs`. For example, if yo
 
 ```elixir
 config :dnsimple, base_url: "https://api.sandbox.dnsimple.com"
+config :dnsimple, access_token: "secret"
+config :dnsimple, user_agent: "my-app"
 ```
 
-Now you can simply call `client = %Dnsimple.Client{access_token: "TOKEN"}`.
+Now you can simply call `client = Dnsimple.Client.new_from_env()`.
 
 ### Logging
 
@@ -173,4 +175,4 @@ client = %Dnsimple.Client{base_url: "https://api.sandbox.dnsimple.com", access_t
 
 ## License
 
-Copyright (c) 2015-2022 DNSimple Corporation. This is Free Software distributed under the MIT license.
+Copyright (c) 2015-2023 DNSimple Corporation. This is Free Software distributed under the MIT license.

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
-# and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+# and its dependencies with the aid of the Config module.
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/lib/dnsimple.ex
+++ b/lib/dnsimple.ex
@@ -150,6 +150,7 @@ defmodule Dnsimple do
         "Accept"        => "application/json",
         "User-Agent"    => format_user_agent(client.user_agent),
         "Authorization" => "Bearer #{client.access_token}",
+        "Content-Type"  => "application/json",
       }
 
       {headers, options} = Keyword.pop(all_options, :headers)

--- a/lib/dnsimple.ex
+++ b/lib/dnsimple.ex
@@ -78,6 +78,21 @@ defmodule Dnsimple do
     @type headers :: [{binary, binary}] | %{binary => binary}
     @type body :: binary | {:form, [{atom, any}]} | {:file, binary}
 
+    @doc """
+    Initializes a new client from the application environment.
+
+    ## Examples
+
+        client = Dnsimple.Client.new_from_env()
+    """
+    @spec new_from_env :: t
+    def new_from_env do
+      %__MODULE__{
+        access_token: Application.get_env(:dnsimple, :access_token),
+        base_url: Application.get_env(:dnsimple, :base_url),
+        user_agent: Application.get_env(:dnsimple, :user_agent)
+      }
+    end
 
     @doc """
     Prepends the correct API version to path.

--- a/lib/dnsimple/zone.ex
+++ b/lib/dnsimple/zone.ex
@@ -19,6 +19,7 @@ defmodule Dnsimple.Zone do
   defstruct ~w(id account_id name reverse created_at updated_at)a
 
   defmodule File do
+    @deprecated "Use Dnsimple.ZoneFile instead"
     @moduledoc """
     Represents a zone file.
 

--- a/lib/dnsimple/zone_file.ex
+++ b/lib/dnsimple/zone_file.ex
@@ -1,0 +1,17 @@
+defmodule Dnsimple.ZoneFile do
+  @moduledoc """
+  Represents a zone file.
+
+  See:
+  - https://developer.dnsimple.com/v2/zones/#file
+  - https://support.dnsimple.com/articles/zone-files/#whats-a-zone-file
+  """
+  @moduledoc section: :data_types
+
+  @type t :: %__MODULE__{
+    zone: String.t,
+  }
+
+  defstruct ~w(zone)a
+
+end

--- a/lib/dnsimple/zones.ex
+++ b/lib/dnsimple/zones.ex
@@ -13,6 +13,7 @@ defmodule Dnsimple.Zones do
   alias Dnsimple.Listing
   alias Dnsimple.Response
   alias Dnsimple.Zone
+  alias Dnsimple.ZoneFile
   alias Dnsimple.ZoneDistribution
   alias Dnsimple.ZoneRecord
 
@@ -80,7 +81,7 @@ defmodule Dnsimple.Zones do
     url = Client.versioned("/#{account_id}/zones/#{zone_id}/file")
 
     Client.get(client, url, options)
-    |> Response.parse(%{"data" => %Zone.File{}})
+    |> Response.parse(%{"data" => %ZoneFile{}})
   end
 
 

--- a/test/dnsimple_test.exs
+++ b/test/dnsimple_test.exs
@@ -9,6 +9,23 @@ defmodule Dnsimple.ClientTest do
     assert client.base_url == "https://api.dnsimple.com"
   end
 
+  describe "when configuration is set" do
+    setup do
+      Application.put_env(:dnsimple, :access_token, "s3cr35")
+      Application.put_env(:dnsimple, :base_url, "https://api.local.dnsimple.test")
+
+      on_exit fn ->
+        Application.delete_env(:dnsimple, :access_token)
+        Application.delete_env(:dnsimple, :base_url)
+      end
+    end
+
+    test "initialize with configuration" do
+      client = Dnsimple.Client.new_from_env()
+      assert client.access_token == "s3cr35"
+      assert client.base_url == "https://api.local.dnsimple.test"
+    end
+  end
 
   describe ".versioned" do
     test "joins path with current api version" do


### PR DESCRIPTION
This PR adds a new method to allow users to initialize the client from the application environment config. Fixes #21.
In addition, all API requests now have the `Content-Type` header set to `application/json`. Fixes #107.

Deprecate `Dnsimple.Zone.File` use instead `Dnsimple.ZoneFile` fixes #116.