### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You will have to add the `:dnsimple` app to your `mix.exs` file as a dependency:
 ```elixir
 def deps do
   [
-    {:dnsimple, "~> 1.0.0"}, #...
+    {:dnsimple, "~> 3.4.0"}, #...
   ]
 end
 ```


### PR DESCRIPTION
Update the README example to a recent version; 1.0.0 is very outdated and causes dependency clashes with common frameworks