### PR TITLE
Add missing attributes to the Zone API responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## main
 
+ENHANCEMENTS:
+
+- NEW: Added `Secondary`, `LastTransferredAt`, `Active` to `Zone` (dnsimple/dnsimple-elixir)
+
 ## 3.6.0
 
 FEATURES:

--- a/lib/dnsimple/zone.ex
+++ b/lib/dnsimple/zone.ex
@@ -12,11 +12,14 @@ defmodule Dnsimple.Zone do
     account_id: integer,
     name: String.t,
     reverse: boolean,
+    secondary: boolean,
+    last_transferred_at: String.t | nil,
+    active: boolean,
     created_at: String.t,
     updated_at: String.t
   }
 
-  defstruct ~w(id account_id name reverse created_at updated_at)a
+  defstruct ~w(id account_id name reverse secondary last_transferred_at active created_at updated_at)a
 
   defmodule File do
     @deprecated "Use Dnsimple.ZoneFile instead"

--- a/test/dnsimple/zones_test.exs
+++ b/test/dnsimple/zones_test.exs
@@ -58,6 +58,9 @@ defmodule Dnsimple.ZonesTest do
         assert data.account_id == @account_id
         assert data.name == "example-alpha.com"
         assert data.reverse == false
+        assert data.secondary == false
+        assert data.last_transferred_at == nil
+        assert data.active == true
         assert data.created_at == "2015-04-23T07:40:03Z"
         assert data.updated_at == "2015-04-23T07:40:03Z"
       end

--- a/test/fixtures.http/getZone/success.http
+++ b/test/fixtures.http/getZone/success.http
@@ -13,4 +13,4 @@ X-Request-Id: 93182033-a215-484e-a107-5235fa48001c
 X-Runtime: 0.177942
 Strict-Transport-Security: max-age=31536000
 
-{"data":{"id":1,"account_id":1010,"name":"example-alpha.com","reverse":false,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}}
+{"data":{"id":1,"account_id":1010,"name":"example-alpha.com","reverse":false,"secondary":false,"last_transferred_at":null,"active":true,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}}

--- a/test/fixtures.http/listZones/success.http
+++ b/test/fixtures.http/listZones/success.http
@@ -13,4 +13,4 @@ X-Request-Id: 01be9fa5-3a00-4d51-a927-f17587cb67ec
 X-Runtime: 0.037083
 Strict-Transport-Security: max-age=31536000
 
-{"data":[{"id":1,"account_id":1010,"name":"example-alpha.com","reverse":false,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"},{"id":2,"account_id":1010,"name":"example-beta.com","reverse":true,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":2,"total_pages":1}}
+{"data":[{"id":1,"account_id":1010,"name":"example-alpha.com","reverse":false,"secondary":false,"last_transferred_at":null,"active":true,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"},{"id":2,"account_id":1010,"name":"example-beta.com","reverse":false,"secondary":false,"last_transferred_at":null,"active":true,"created_at":"2015-04-23T07:40:03Z","updated_at":"2015-04-23T07:40:03Z"}],"pagination":{"current_page":1,"per_page":30,"total_entries":2,"total_pages":1}}


### PR DESCRIPTION
This PR adds [missing attributes](https://github.com/dnsimple/dnsimple-developer/pull/542) of the Zone response:

- `secondary`, `last_transferred_at`, `active` to `Zone` struct

Belongs to https://github.com/dnsimple/dnsimple-external-integrations/issues/17