### PR TITLE
Domain transfer lock API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ FEATURES:
 - NEW: Added `Dnsimple.Registrar.disable_domain_transfer_lock` to disable the domain transfer lock for a domain. (#244)
 - NEW: Added `Dnsimple.Registrar.get_domain_transfer_lock` to get the domain transfer lock status for a domain. (#244)
 
-
 ## 3.7.0
 
 ENHANCEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## main
 
+FEATURES:
+
+- NEW: Added `Dnsimple.Registrar.enable_domain_transfer_lock` to enable the domain transfer lock for a domain. (#244)
+- NEW: Added `Dnsimple.Registrar.disable_domain_transfer_lock` to disable the domain transfer lock for a domain. (#244)
+- NEW: Added `Dnsimple.Registrar.get_domain_transfer_lock` to get the domain transfer lock status for a domain. (#244)
+
+
 ## 3.7.0
 
 ENHANCEMENTS:

--- a/lib/dnsimple/registrar.ex
+++ b/lib/dnsimple/registrar.ex
@@ -12,18 +12,19 @@ defmodule Dnsimple.Registrar do
   @moduledoc section: :api
 
   alias Dnsimple.Client
-  alias Dnsimple.Response
   alias Dnsimple.DomainCheck
   alias Dnsimple.DomainPremiumPrice
   alias Dnsimple.DomainPrice
   alias Dnsimple.DomainRegistration
   alias Dnsimple.DomainRenewal
   alias Dnsimple.DomainTransfer
+  alias Dnsimple.RegistrantChange
+  alias Dnsimple.RegistrantChangeCheck
+  alias Dnsimple.Response
+  alias Dnsimple.TransferLock
+  alias Dnsimple.VanityNameServer
   alias Dnsimple.WhoisPrivacy
   alias Dnsimple.WhoisPrivacyRenewal
-  alias Dnsimple.VanityNameServer
-  alias Dnsimple.RegistrantChangeCheck
-  alias Dnsimple.RegistrantChange
 
   @doc """
   Checks if a domain name is available to be registered and whether premium
@@ -306,6 +307,62 @@ defmodule Dnsimple.Registrar do
     |> Response.parse(nil)
   end
 
+  @doc """
+  Enables transfer lock for the domain.
+
+  See:
+  - https://developer.dnsimple.com/v2/registrar/transfer_lock/#enableDomainTransferLock
+
+  ## Examples:
+
+      client = %Dnsimple.Client{access_token: "a1b2c3d4"}
+      {:ok, response} = Dnsimple.Registrar.enable_domain_transfer_lock(client, account_id = 1010, domain_id = "example.com")
+  """
+  @spec enable_domain_transfer_lock(Client.t, integer | String.t, String.t, Keyword.t) :: {:ok|:error, Response.t}
+  def enable_domain_transfer_lock(client, account_id, domain_name, options \\ []) do
+    url = Client.versioned("/#{account_id}/registrar/domains/#{domain_name}/transfer_lock")
+
+    Client.post(client, url, Client.empty_body(), options)
+    |> Response.parse(%{"data" => %TransferLock{}})
+  end
+
+  @doc """
+  Disables transfer lock for the domain.
+
+  See:
+  - https://developer.dnsimple.com/v2/registrar/transfer_lock/#disableDomainTransferLock
+
+  ## Examples:
+
+      client = %Dnsimple.Client{access_token: "a1b2c3d4"}
+      {:ok, response} = Dnsimple.Registrar.disable_domain_transfer_lock(client, account_id = 1010, domain_id = "example.com")
+  """
+  @spec disable_domain_transfer_lock(Client.t, integer | String.t, String.t, Keyword.t) :: {:ok|:error, Response.t}
+  def disable_domain_transfer_lock(client, account_id, domain_name, options \\ []) do
+    url = Client.versioned("/#{account_id}/registrar/domains/#{domain_name}/transfer_lock")
+
+    Client.delete(client, url, options)
+    |> Response.parse(%{"data" => %TransferLock{}})
+  end
+
+  @doc """
+  Retrieves the transfer lock status for the domain.
+
+  See:
+  - https://developer.dnsimple.com/v2/registrar/transfer_lock/#getDomainTransferLock
+
+  ## Examples:
+
+      client = %Dnsimple.Client{access_token: "a1b2c3d4"}
+      {:ok, response} = Dnsimple.Registrar.get_domain_transfer_lock(client, account_id = 1010, domain_id = "example.com")
+  """
+  @spec get_domain_transfer_lock(Client.t, integer | String.t, String.t, Keyword.t) :: {:ok|:error, Response.t}
+  def get_domain_transfer_lock(client, account_id, domain_name, options \\ []) do
+    url = Client.versioned("/#{account_id}/registrar/domains/#{domain_name}/transfer_lock")
+
+    Client.get(client, url, options)
+    |> Response.parse(%{"data" => %TransferLock{}})
+  end
 
   @doc """
   Returns the whois privacy of the domain.

--- a/lib/dnsimple/transfer_lock.ex
+++ b/lib/dnsimple/transfer_lock.ex
@@ -1,0 +1,16 @@
+defmodule Dnsimple.TransferLock do
+  @moduledoc """
+  Represents the transfer lock status for a domain.
+
+  See:
+  - https://developer.dnsimple.com/v2/registrar/transfer_lock/
+  """
+  @moduledoc section: :data_types
+
+  @type t :: %__MODULE__{
+    enabled: boolean(),
+  }
+
+  defstruct ~w(enabled)a
+
+end

--- a/test/dnsimple/registrar_test.exs
+++ b/test/dnsimple/registrar_test.exs
@@ -310,6 +310,58 @@ defmodule Dnsimple.RegistrarTest do
   end
 
 
+  describe ".enable_domain_transfer_lock" do
+    test "enables the transfer lock for the domain and returns an empty Dnsimple.Response" do
+      url     = "#{@client.base_url}/v2/#{@account_id}/registrar/domains/example.com/transfer_lock"
+      method  = "post"
+      fixture = "enableDomainTransferLock/success.http"
+
+      use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url) do
+        {:ok, response} = @module.enable_domain_transfer_lock(@client, @account_id, "example.com")
+        assert response.__struct__ == Dnsimple.Response
+
+        data = response.data
+        assert data.__struct__ == Dnsimple.TransferLock
+        assert data.enabled == true
+      end
+    end
+  end
+
+  describe ".disable_domain_transfer_lock" do
+    test "disables the transfer lock for the domain and returns an empty Dnsimple.Response" do
+      url     = "#{@client.base_url}/v2/#{@account_id}/registrar/domains/example.com/transfer_lock"
+      method  = "delete"
+      fixture = "disableDomainTransferLock/success.http"
+
+      use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url) do
+        {:ok, response} = @module.disable_domain_transfer_lock(@client, @account_id, "example.com")
+        assert response.__struct__ == Dnsimple.Response
+
+        data = response.data
+        assert data.__struct__ == Dnsimple.TransferLock
+        assert data.enabled == false
+      end
+    end
+  end
+
+  describe ".get_domain_transfer_lock" do
+    test "returns the transfer lock for the domain in a Dnsimple.Response" do
+      url     = "#{@client.base_url}/v2/#{@account_id}/registrar/domains/example.com/transfer_lock"
+      method  = "get"
+      fixture = "getDomainTransferLock/success.http"
+
+      use_cassette :stub, ExvcrUtils.response_fixture(fixture, method: method, url: url) do
+        {:ok, response} = @module.get_domain_transfer_lock(@client, @account_id, "example.com")
+        assert response.__struct__ == Dnsimple.Response
+
+        data = response.data
+        assert data.__struct__ == Dnsimple.TransferLock
+        assert data.enabled == true
+      end
+    end
+  end
+
+
   describe ".get_whois_privacy" do
     test "returns the whois privacy in a Dnsimple.Response" do
       url     = "#{@client.base_url}/v2/#{@account_id}/registrar/domains/example.com/whois_privacy"

--- a/test/fixtures.http/disableDomainTransferLock/success.http
+++ b/test/fixtures.http/disableDomainTransferLock/success.http
@@ -1,0 +1,20 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Tue, 15 Aug 2023 09:58:37 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2398
+X-RateLimit-Reset: 1488538623
+ETag: W/"fc2368a31a1b6a3afcca33bb37ff6b9d"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 8b0fe49a-c810-4552-84ab-a1cd9b4a7786
+X-Runtime: 0.024780
+X-Content-Type-Options: nosniff
+X-Download-Options: noopen
+X-Frame-Options: DENY
+X-Permitted-Cross-Domain-Policies: none
+X-XSS-Protection: 1; mode=block
+Strict-Transport-Security: max-age=31536000
+
+{"data":{"enabled":false}}

--- a/test/fixtures.http/enableDomainTransferLock/success.http
+++ b/test/fixtures.http/enableDomainTransferLock/success.http
@@ -1,0 +1,20 @@
+HTTP/1.1 201 Created
+Server: nginx
+Date: Tue, 15 Aug 2023 09:58:37 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2398
+X-RateLimit-Reset: 1488538623
+ETag: W/"fc2368a31a1b6a3afcca33bb37ff6b9d"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 8b0fe49a-c810-4552-84ab-a1cd9b4a7786
+X-Runtime: 0.024780
+X-Content-Type-Options: nosniff
+X-Download-Options: noopen
+X-Frame-Options: DENY
+X-Permitted-Cross-Domain-Policies: none
+X-XSS-Protection: 1; mode=block
+Strict-Transport-Security: max-age=31536000
+
+{"data":{"enabled":true}}

--- a/test/fixtures.http/getDomainTransferLock/success.http
+++ b/test/fixtures.http/getDomainTransferLock/success.http
@@ -1,0 +1,20 @@
+HTTP/1.1 200 OK
+Server: nginx
+Date: Tue, 15 Aug 2023 09:58:37 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-RateLimit-Limit: 2400
+X-RateLimit-Remaining: 2398
+X-RateLimit-Reset: 1488538623
+ETag: W/"fc2368a31a1b6a3afcca33bb37ff6b9d"
+Cache-Control: max-age=0, private, must-revalidate
+X-Request-Id: 8b0fe49a-c810-4552-84ab-a1cd9b4a7786
+X-Runtime: 0.024780
+X-Content-Type-Options: nosniff
+X-Download-Options: noopen
+X-Frame-Options: DENY
+X-Permitted-Cross-Domain-Policies: none
+X-XSS-Protection: 1; mode=block
+Strict-Transport-Security: max-age=31536000
+
+{"data":{"enabled":true}}


### PR DESCRIPTION
This PR introduces 3 new endpoints that are part of the domain transfer lock API that is introduced in https://github.com/dnsimple/dnsimple-developer/pull/519.

The following endpoints have been added:
- **getDomainTransferLock**: GET `/{account}/registrar/domains/{domain}/transfer_lock`
- **enableDomainTransferLock**: POST `/{account}/registrar/domains/{domain}/transfer_lock`
- **disableDomainTransferLock**: DELETE `/{account}/registrar/domains/{domain}/transfer_lock`

Belongs to https://github.com/dnsimple/dnsimple-business/issues/1728
Belongs to https://github.com/dnsimple/dnsimple-external-integrations/issues/18