### PR TITLE
Update CI github runner and bumps OTP/Elixir versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
 
   test:
     needs: [markdownlint-cli]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     name: Elixir ${{matrix.elixir}} / OTP ${{matrix.otp}}
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,30 +30,18 @@ jobs:
     strategy:
       matrix:
         # Only support last 5 minor versions (https://hexdocs.pm/elixir/compatibility-and-deprecations.html)
-        elixir: ['1.13', '1.14', '1.15', '1.16', '1.17']
-        otp: ['23.0', '24.0', '25.0', '26.0', '27.0']
+        elixir: ['1.14', '1.15', '1.16', '1.17', '1.18']
+        otp: ['25.0', '26.0', '27.0']
         # As per https://hexdocs.pm/elixir/compatibility-and-deprecations.html#compatibility-between-elixir-and-erlang-otp
         exclude:
-          - elixir: '1.13'
-            otp: '26.0'
-          - elixir: '1.13'
-            otp: '27.0'
           - elixir: '1.14'
             otp: '26.0'
           - elixir: '1.14'
             otp: '27.0'
           - elixir: '1.15'
-            otp: '23.0'
-          - elixir: '1.15'
             otp: '27.0'
           - elixir: '1.16'
-            otp: '23.0'
-          - elixir: '1.16'
             otp: '27.0'
-          - elixir: '1.17'
-            otp: '23.0'
-          - elixir: '1.17'
-            otp: '24.0'
     steps:
       - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,14 +18,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 5.0.0
 
 - NEW: Added `alias_email` and `destination_email` to `Dnsimple.EmailForward`
-- NEW: Added support for Elixir 2.17
-- CHANGED: Requires Elixir >= 2.13 and OTP >= 23
+- NEW: Added support for Elixir 1.17
+- CHANGED: Requires Elixir >= 1.13 and OTP >= 23
 - CHANGED: `DomainCollaborators` have been deprecated and will be removed in the next major version. Please use our Domain Access Control feature.
 
 ## 4.0.0
 
-- CHANGED: Requires Elixir >= 2.12 and OTP >= 22
-- NEW: Added support for Elixir 2.16
+- CHANGED: Requires Elixir >= 1.12 and OTP >= 22
+- NEW: Added support for Elixir 1.16
 
 ## 3.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## main
 
+- NEW: Added support for Elixir 1.18
+- CHANGED: Requires Elixir >= 1.14 and OTP >= 25
+- FIXED: Fixed Elixir versions explicited in CHANGELOG.md and README.md 
+
 ## 5.0.1
 
 - Test build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - NEW: Added support for Elixir 1.18
 - CHANGED: Requires Elixir >= 1.14 and OTP >= 25
-- FIXED: Fixed Elixir versions explicited in CHANGELOG.md and README.md 
+- FIXED: Fixed Elixir versions explicited in CHANGELOG.md and README.md
 
 ## 5.0.1
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ An Elixir client for the [DNSimple API v2](https://developer.dnsimple.com/v2/).
 
 ## Requirements
 
-* Elixir: 1.13+
-* OTP: 23.0+
+* Elixir: 1.14+
+* OTP: 25.0+
 
 ## Installation
 


### PR DESCRIPTION
This PR aims to update the deprecated CI runner ubuntu-20.04 to ubuntu-latest

Also fixes / updates the test matrix according to the stable OTP and Elixir versions (in order to have CI passing!)
- https://elixir-lang.org/docs.html
- https://github.com/erlang/otp/security#supported-versions

And fixes a series of typos in CHANGELOG.md

# Deploy steps

- [x] Merge 
- [ ] Cut a major release