### PR TITLE
Patch cycle - 2025 / Cycle 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## main
 
+- HOUSEKEEPING: Bump httpoison from 2.2.1 to 2.2.3 (#271)
+- HOUSEKEEPING: Bump exvcr from 0.15.1 to 0.17.0  (#270)
+- HOUSEKEEPING: Bump ex_doc from 0.34.1 to 0.37.3  (#269)
+
 ## 6.0.0
 
 - NEW: Added support for Elixir 1.18


### PR DESCRIPTION
The changes to go out in the next version (6.0.1) are:

- HOUSEKEEPING: #271
- HOUSEKEEPING: #270
- HOUSEKEEPING: #269

Belongs to https://github.com/dnsimple/dnsimple-engineering/issues/297
Belongs to https://github.com/dnsimple/dnsimple-engineering/issues/294