### PR TITLE
Remove from and to from EmailForward model

### DIFF
--- a/lib/dnsimple/email_forward.ex
+++ b/lib/dnsimple/email_forward.ex
@@ -10,8 +10,6 @@ defmodule Dnsimple.EmailForward do
   @type t :: %__MODULE__{
     id: integer,
     domain_id: integer,
-    from: String.t,
-    to: String.t,
     alias_email: String.t,
     destination_email: String.t,
     created_at: String.t,

--- a/test/dnsimple/domains_test.exs
+++ b/test/dnsimple/domains_test.exs
@@ -341,8 +341,6 @@ defmodule Dnsimple.DomainsTest do
         assert data.__struct__ == Dnsimple.EmailForward
         assert data.id == 41872
         assert data.domain_id == 235146
-        assert data.from == "example@dnsimple.xyz"
-        assert data.to == "example@example.com"
         assert data.alias_email == "example@dnsimple.xyz"
         assert data.destination_email == "example@example.com"
         assert data.created_at == "2021-01-25T13:54:40Z"


### PR DESCRIPTION
Belongs to https://github.com/dnsimple/dnsimple-app/issues/17733.

## Description
This PR removes the deprecated `from` and `to` models from the `EmailForward` model.